### PR TITLE
Support for manually triggered redraw of terminal.

### DIFF
--- a/eventqueue/eventqueue.go
+++ b/eventqueue/eventqueue.go
@@ -75,6 +75,13 @@ func (u *Unbound) wake() {
 	}
 }
 
+// Empty determines if the queue is empty.
+func (u *Unbound) Empty() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.empty()
+}
+
 // empty determines if the queue is empty.
 func (u *Unbound) empty() bool {
 	return u.first == nil

--- a/eventqueue/eventqueue_test.go
+++ b/eventqueue/eventqueue_test.go
@@ -25,12 +25,14 @@ import (
 
 func TestQueue(t *testing.T) {
 	tests := []struct {
-		desc     string
-		pushes   []terminalapi.Event
-		wantPops []terminalapi.Event
+		desc      string
+		pushes    []terminalapi.Event
+		wantEmpty bool // Checked after pushes and before pops.
+		wantPops  []terminalapi.Event
 	}{
 		{
-			desc: "empty queue returns nil",
+			desc:      "empty queue returns nil",
+			wantEmpty: true,
 			wantPops: []terminalapi.Event{
 				nil,
 			},
@@ -42,6 +44,7 @@ func TestQueue(t *testing.T) {
 				terminalapi.NewError("error2"),
 				terminalapi.NewError("error3"),
 			},
+			wantEmpty: false,
 			wantPops: []terminalapi.Event{
 				terminalapi.NewError("error1"),
 				terminalapi.NewError("error2"),
@@ -57,6 +60,11 @@ func TestQueue(t *testing.T) {
 			defer q.Close()
 			for _, ev := range tc.pushes {
 				q.Push(ev)
+			}
+
+			gotEmpty := q.Empty()
+			if gotEmpty != tc.wantEmpty {
+				t.Errorf("Empty => got %v, want %v", gotEmpty, tc.wantEmpty)
 			}
 
 			for i, want := range tc.wantPops {

--- a/termdash_test.go
+++ b/termdash_test.go
@@ -529,13 +529,13 @@ func TestController(t *testing.T) {
 				tc.apiEvents(mi)
 			}
 
+			if err := untilEmpty(5*time.Second, eq); err != nil {
+				t.Fatalf("untilEmpty => %v", err)
+			}
 			if tc.controls != nil {
 				if err := tc.controls(ctrl); err != nil {
 					t.Errorf("controls => unexpected error: %v", err)
 				}
-			}
-			if err := untilEmpty(5*time.Second, eq); err != nil {
-				t.Fatalf("untilEmpty => %v", err)
 			}
 
 			if diff := faketerm.Diff(tc.want(got.Size()), got); diff != "" {


### PR DESCRIPTION
- Adding a Controller object that allows triggering of redraw manually.
- The eventqueue now has an Empty() method to determine if it has been emptied.
- The fake widget can now display a custom text, needed for tests that want to verify if redraw happened or not.
- Improving test coverage in the fakewidget.
- Fixing two races in the termdash_test.
-- Race1: Waiting for event queue to empty before examining the fake terminal. This ensures that events were processed.
-- Race2: Moving the test of terminal resize into the group of tests that use the triggered redraw, as that is a convenient way of ensuring that we resize, then redraw and then compare the content.

Fixes #27 