### PR TITLE
Hotfix v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 12-Feb-2019
+
+### Fixes
+
+- The LineChart widget now correctly places custom labels.
+
 ## [0.6.0] - 07-Feb-2019
 
 ### Added
@@ -83,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Gauge widget.
 - The Text widget.
 
-[Unreleased]: https://github.com/mum4k/termdash/compare/v0.6.0...devel
+[Unreleased]: https://github.com/mum4k/termdash/compare/v0.6.1...devel
+[0.6.1]: https://github.com/mum4k/termdash/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mum4k/termdash/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mum4k/termdash/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mum4k/termdash/compare/v0.3.0...v0.4.0

--- a/widgets/linechart/axes/label.go
+++ b/widgets/linechart/axes/label.go
@@ -169,7 +169,7 @@ func xLabels(scale *XScale, graphZero image.Point, customLabels map[int]string) 
 
 	next := 0
 	for haveLabels := 0; haveLabels <= int(scale.Max.Value); haveLabels = len(res) {
-		label, err := colLabel(scale, space, next, customLabels)
+		label, err := colLabel(scale, space, customLabels)
 		if err != nil {
 			return nil, err
 		}
@@ -202,23 +202,21 @@ func xLabels(scale *XScale, graphZero image.Point, customLabels map[int]string) 
 	return res, nil
 }
 
-// colLabel returns a label placed either at the beginning of the space.
+// colLabel returns a label placed at the beginning of the space.
 // The space is adjusted according to how much space was taken by the label.
 // Returns nil, nil if the label doesn't fit in the space.
-func colLabel(scale *XScale, space *xSpace, labelNum int, customLabels map[int]string) (*Label, error) {
-	var val *Value
-	if custom, ok := customLabels[labelNum]; ok {
-		val = NewTextValue(custom)
-	} else {
-		pos := space.Relative()
-		v, err := scale.CellLabel(pos.X)
-		if err != nil {
-			return nil, fmt.Errorf("unable to determine label value for column %d: %v", pos.X, err)
-		}
-		val = v
+func colLabel(scale *XScale, space *xSpace, customLabels map[int]string) (*Label, error) {
+	pos := space.Relative()
+	label, err := scale.CellLabel(pos.X)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine label value for column %d: %v", pos.X, err)
 	}
 
-	labelLen := len(val.Text())
+	if custom, ok := customLabels[int(label.Value)]; ok {
+		label = NewTextValue(custom)
+	}
+
+	labelLen := len(label.Text())
 	if labelLen > space.Remaining() {
 		return nil, nil
 	}
@@ -229,7 +227,7 @@ func colLabel(scale *XScale, space *xSpace, labelNum int, customLabels map[int]s
 	}
 
 	return &Label{
-		Value: val,
+		Value: label,
 		Pos:   abs,
 	}, nil
 }

--- a/widgets/linechart/axes/label_test.go
+++ b/widgets/linechart/axes/label_test.go
@@ -266,6 +266,26 @@ func TestXLabels(t *testing.T) {
 			},
 		},
 		{
+			desc:       "custom labels provided, but only some fit, regression for #117",
+			numPoints:  8,
+			graphWidth: 5,
+			graphZero:  image.Point{0, 1},
+			customLabels: map[int]string{
+				0: "a",
+				1: "b",
+				2: "c",
+				3: "d",
+				4: "e",
+				5: "f",
+				6: "g",
+				7: "h",
+			},
+			want: []*Label{
+				{NewTextValue("a"), image.Point{0, 3}},
+				{NewTextValue("g"), image.Point{4, 3}},
+			},
+		},
+		{
 			desc:       "only some custom labels provided",
 			numPoints:  4,
 			graphWidth: 100,

--- a/widgets/linechart/linechartdemo/linechartdemo.go
+++ b/widgets/linechart/linechartdemo/linechartdemo.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -48,15 +49,23 @@ func playLineChart(ctx context.Context, lc *linechart.LineChart, delay time.Dura
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 	for i := 0; ; {
+		labels := map[int]string{}
+		for i := 0; i < 200; i++ {
+			labels[i] = fmt.Sprintf("l%d", i)
+		}
+
 		select {
 		case <-ticker.C:
 			i = (i + 1) % len(inputs)
 			rotated := append(inputs[i:], inputs[:i]...)
 			if err := lc.Series("first", rotated,
 				linechart.SeriesCellOpts(cell.FgColor(cell.ColorBlue)),
-				linechart.SeriesXLabels(map[int]string{
-					0: "zero",
-				}),
+				/*
+					linechart.SeriesXLabels(map[int]string{
+						0: "zero",
+					}),
+				*/
+				linechart.SeriesXLabels(labels),
 			); err != nil {
 				panic(err)
 			}

--- a/widgets/linechart/linechartdemo/linechartdemo.go
+++ b/widgets/linechart/linechartdemo/linechartdemo.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"time"
 
@@ -49,23 +48,15 @@ func playLineChart(ctx context.Context, lc *linechart.LineChart, delay time.Dura
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 	for i := 0; ; {
-		labels := map[int]string{}
-		for i := 0; i < 200; i++ {
-			labels[i] = fmt.Sprintf("l%d", i)
-		}
-
 		select {
 		case <-ticker.C:
 			i = (i + 1) % len(inputs)
 			rotated := append(inputs[i:], inputs[:i]...)
 			if err := lc.Series("first", rotated,
 				linechart.SeriesCellOpts(cell.FgColor(cell.ColorBlue)),
-				/*
-					linechart.SeriesXLabels(map[int]string{
-						0: "zero",
-					}),
-				*/
-				linechart.SeriesXLabels(labels),
+				linechart.SeriesXLabels(map[int]string{
+					0: "zero",
+				}),
 			); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
The LineChart widget now correctly places custom labels.
- The code incorrectly used label number rather than value position when
looking up custom labels.

Fixes #117 