### PR TITLE
Fixing invalid zooming behaviors.

### DIFF
--- a/widgets/linechart/axes/axes.go
+++ b/widgets/linechart/axes/axes.go
@@ -152,6 +152,11 @@ type XDetails struct {
 	Properties *XProperties
 }
 
+// String implements fmt.Stringer.
+func (xd *XDetails) String() string {
+	return fmt.Sprintf("XDetails{Scale:%v}", xd.Scale)
+}
+
 // XProperties are the properties of the X axis.
 type XProperties struct {
 	// Min is the minimum value on the axis, i.e. the position of the first

--- a/widgets/linechart/axes/axes_test.go
+++ b/widgets/linechart/axes/axes_test.go
@@ -15,6 +15,7 @@
 package axes
 
 import (
+	"fmt"
 	"image"
 	"testing"
 
@@ -441,6 +442,7 @@ func TestNewXDetails(t *testing.T) {
 			if err != nil {
 				return
 			}
+			t.Log(fmt.Sprintf("got: %v", got))
 
 			if diff := pretty.Compare(tc.want, got); diff != "" {
 				t.Errorf("NewXDetails => unexpected diff (-want, +got):\n%s", diff)

--- a/widgets/linechart/axes/scale.go
+++ b/widgets/linechart/axes/scale.go
@@ -235,6 +235,11 @@ func NewXScale(min, max int, graphWidth, nonZeroDecimals int) (*XScale, error) {
 	}, nil
 }
 
+// String implements fmt.Stringer.
+func (xs *XScale) String() string {
+	return fmt.Sprintf("XScale{Min:%v, Max:%v, Step:%v, GraphWidth:%v}", xs.Min, xs.Max, xs.Step, xs.GraphWidth)
+}
+
 // PixelToValue given a X coordinate of the pixel, returns its value according
 // to the scale. The coordinate must be within bounds of the canvas width
 // provided to NewXScale. X coordinates grow right.

--- a/widgets/linechart/axes/scale_test.go
+++ b/widgets/linechart/axes/scale_test.go
@@ -1142,6 +1142,7 @@ func TestXScale(t *testing.T) {
 		if err != nil {
 			continue
 		}
+		t.Log(fmt.Sprintf("scale:%v", scale))
 
 		t.Run(fmt.Sprintf("PixelToValue:%s", test.desc), func(t *testing.T) {
 			for _, tc := range test.pixelToValueTests {

--- a/widgets/linechart/axes/value.go
+++ b/widgets/linechart/axes/value.go
@@ -43,7 +43,7 @@ type Value struct {
 
 // String implements fmt.Stringer.
 func (v *Value) String() string {
-	return fmt.Sprintf("Value{%v, %v}", v.Value, v.Rounded)
+	return fmt.Sprintf("Value{Round(%v) => %v}", v.Value, v.Rounded)
 }
 
 // NewValue returns a new instance representing the provided value, rounding

--- a/widgets/linechart/linechart.go
+++ b/widgets/linechart/linechart.go
@@ -272,7 +272,6 @@ func (lc *LineChart) axesDetails(cvs *canvas.Canvas) (*axes.XDetails, *axes.YDet
 		return nil, nil, fmt.Errorf("NewYDetails => %v", err)
 	}
 
-	// TODO: Zoom the X axis.
 	const xMin = 0
 	xMax := lc.maxXValue()
 	xd, err := lc.xDetails(cvs, yd.Start.X, xMin, xMax)
@@ -463,6 +462,9 @@ func (lc *LineChart) Keyboard(k *terminalapi.Keyboard) error {
 
 // Mouse implements widgetapi.Widget.Mouse.
 func (lc *LineChart) Mouse(m *terminalapi.Mouse) error {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+
 	if lc.zoom == nil {
 		return nil
 	}
@@ -485,8 +487,8 @@ func (lc *LineChart) minSize() image.Point {
 
 // Options implements widgetapi.Widget.Options.
 func (lc *LineChart) Options() widgetapi.Options {
-	lc.mu.Lock()
-	defer lc.mu.Unlock()
+	lc.mu.RLock()
+	defer lc.mu.RUnlock()
 
 	return widgetapi.Options{
 		MinimumSize: lc.minSize(),

--- a/widgets/linechart/linechartdemo/linechartdemo.go
+++ b/widgets/linechart/linechartdemo/linechartdemo.go
@@ -44,28 +44,38 @@ func sineInputs() []float64 {
 // playLineChart continuously adds values to the LineChart, once every delay.
 // Exits when the context expires.
 func playLineChart(ctx context.Context, lc *linechart.LineChart, delay time.Duration) {
-	inputs := sineInputs()
+	//inputs := sineInputs()
+	var inputs []float64
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 	for i := 0; ; {
 		select {
 		case <-ticker.C:
-			i = (i + 1) % len(inputs)
-			rotated := append(inputs[i:], inputs[:i]...)
-			if err := lc.Series("first", rotated,
+			//i = (i + 1) % len(inputs)
+			inputs = append(inputs, float64(i%30))
+			if err := lc.Series("first", inputs,
 				linechart.SeriesCellOpts(cell.FgColor(cell.ColorBlue)),
-				linechart.SeriesXLabels(map[int]string{
-					0: "zero",
-				}),
 			); err != nil {
 				panic(err)
 			}
+			i++
 
-			i2 := (i + 100) % len(inputs)
-			rotated2 := append(inputs[i2:], inputs[:i2]...)
-			if err := lc.Series("second", rotated2, linechart.SeriesCellOpts(cell.FgColor(cell.ColorWhite))); err != nil {
-				panic(err)
-			}
+			/*
+				rotated := append(inputs[i:], inputs[:i]...)
+				if err := lc.Series("first", rotated,
+					linechart.SeriesCellOpts(cell.FgColor(cell.ColorBlue)),
+					linechart.SeriesXLabels(map[int]string{
+						0: "zero",
+					}),
+				); err != nil {
+					panic(err)
+				}
+
+				i2 := (i + 100) % len(inputs)
+				rotated2 := append(inputs[i2:], inputs[:i2]...)
+				if err := lc.Series("second", rotated2, linechart.SeriesCellOpts(cell.FgColor(cell.ColorWhite))); err != nil {
+					panic(err)
+				}*/
 
 		case <-ctx.Done():
 			return
@@ -86,11 +96,12 @@ func main() {
 		linechart.AxesCellOpts(cell.FgColor(cell.ColorRed)),
 		linechart.YLabelCellOpts(cell.FgColor(cell.ColorGreen)),
 		linechart.XLabelCellOpts(cell.FgColor(cell.ColorCyan)),
+		//linechart.XAxisUnscaled(),
 	)
 	if err != nil {
 		panic(err)
 	}
-	go playLineChart(ctx, lc, redrawInterval/3)
+	go playLineChart(ctx, lc, redrawInterval/10)
 	c, err := container.New(
 		t,
 		container.Border(draw.LineStyleLight),

--- a/widgets/linechart/linechartdemo/linechartdemo.go
+++ b/widgets/linechart/linechartdemo/linechartdemo.go
@@ -44,38 +44,28 @@ func sineInputs() []float64 {
 // playLineChart continuously adds values to the LineChart, once every delay.
 // Exits when the context expires.
 func playLineChart(ctx context.Context, lc *linechart.LineChart, delay time.Duration) {
-	//inputs := sineInputs()
-	var inputs []float64
+	inputs := sineInputs()
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 	for i := 0; ; {
 		select {
 		case <-ticker.C:
-			//i = (i + 1) % len(inputs)
-			inputs = append(inputs, float64(i%30))
-			if err := lc.Series("first", inputs,
+			i = (i + 1) % len(inputs)
+			rotated := append(inputs[i:], inputs[:i]...)
+			if err := lc.Series("first", rotated,
 				linechart.SeriesCellOpts(cell.FgColor(cell.ColorBlue)),
+				linechart.SeriesXLabels(map[int]string{
+					0: "zero",
+				}),
 			); err != nil {
 				panic(err)
 			}
-			i++
 
-			/*
-				rotated := append(inputs[i:], inputs[:i]...)
-				if err := lc.Series("first", rotated,
-					linechart.SeriesCellOpts(cell.FgColor(cell.ColorBlue)),
-					linechart.SeriesXLabels(map[int]string{
-						0: "zero",
-					}),
-				); err != nil {
-					panic(err)
-				}
-
-				i2 := (i + 100) % len(inputs)
-				rotated2 := append(inputs[i2:], inputs[:i2]...)
-				if err := lc.Series("second", rotated2, linechart.SeriesCellOpts(cell.FgColor(cell.ColorWhite))); err != nil {
-					panic(err)
-				}*/
+			i2 := (i + 100) % len(inputs)
+			rotated2 := append(inputs[i2:], inputs[:i2]...)
+			if err := lc.Series("second", rotated2, linechart.SeriesCellOpts(cell.FgColor(cell.ColorWhite))); err != nil {
+				panic(err)
+			}
 
 		case <-ctx.Done():
 			return
@@ -96,12 +86,11 @@ func main() {
 		linechart.AxesCellOpts(cell.FgColor(cell.ColorRed)),
 		linechart.YLabelCellOpts(cell.FgColor(cell.ColorGreen)),
 		linechart.XLabelCellOpts(cell.FgColor(cell.ColorCyan)),
-		//linechart.XAxisUnscaled(),
 	)
 	if err != nil {
 		panic(err)
 	}
-	go playLineChart(ctx, lc, redrawInterval/10)
+	go playLineChart(ctx, lc, redrawInterval/3)
 	c, err := container.New(
 		t,
 		container.Border(draw.LineStyleLight),


### PR DESCRIPTION
- stay unzoomed when we hit the largest view.
- correctly normalize zoom values when the base axis is in motion.
- test coverage for the edge cases.
- acquire mutex on mouse events.

Fixes #136