### PR TITLE
Allow empty values on line chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The grid.Builder API now allows users to specify options for intermediate
   containers, i.e. containers that don't have widgets, but represent rows and
   columns.
+- Line chart widget now allows `math.NaN` values to represent "no value" (values
+  that will not be rendered) in the values slice.
 
 #### Breaking API changes
 
@@ -85,10 +87,10 @@ identifiers shouldn't be used externally.
 - The draw.LineStyle enum was refactored into its own package
   linestyle.LineStyle. Users will have to replace:
 
-  -  draw.LineStyleNone -> linestyle.None
-  -  draw.LineStyleLight -> linestyle.Light
-  -  draw.LineStyleDouble -> linestyle.Double
-  -  draw.LineStyleRound -> linestyle.Round
+  - draw.LineStyleNone -> linestyle.None
+  - draw.LineStyleLight -> linestyle.Light
+  - draw.LineStyleDouble -> linestyle.Double
+  - draw.LineStyleRound -> linestyle.Round
 
 ## [0.7.0] - 24-Feb-2019
 
@@ -121,7 +123,6 @@ identifiers shouldn't be used externally.
 
 - The Text widget now has a Write option that atomically replaces the entire
   text content.
-
 
 #### Improvements to the infrastructure
 
@@ -251,7 +252,7 @@ identifiers shouldn't be used externally.
 - The Gauge widget.
 - The Text widget.
 
-[Unreleased]: https://github.com/mum4k/termdash/compare/v0.8.0...devel
+[unreleased]: https://github.com/mum4k/termdash/compare/v0.8.0...devel
 [0.8.0]: https://github.com/mum4k/termdash/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/mum4k/termdash/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/mum4k/termdash/compare/v0.7.0...v0.7.1

--- a/internal/numbers/numbers.go
+++ b/internal/numbers/numbers.go
@@ -109,14 +109,18 @@ func Round(x float64) float64 {
 
 // MinMax returns the smallest and the largest value among the provided values.
 // Returns (0, 0) if there are no values.
+// Ignores NaN values.
 func MinMax(values []float64) (min, max float64) {
 	if len(values) == 0 {
 		return 0, 0
 	}
 	min = math.MaxFloat64
 	max = -1 * math.MaxFloat64
-
 	for _, v := range values {
+		if math.IsNaN(v) {
+			continue
+		}
+
 		if v < min {
 			min = v
 		}

--- a/internal/numbers/numbers.go
+++ b/internal/numbers/numbers.go
@@ -109,7 +109,7 @@ func Round(x float64) float64 {
 
 // MinMax returns the smallest and the largest value among the provided values.
 // Returns (0, 0) if there are no values.
-// Ignores NaN values. Allowing NaN values could led in a corner case where all
+// Ignores NaN values. Allowing NaN values could lead to a corner case where all
 // values can be NaN, in this case the function will return NaN as min and max.
 func MinMax(values []float64) (min, max float64) {
 	if len(values) == 0 {

--- a/internal/numbers/numbers.go
+++ b/internal/numbers/numbers.go
@@ -109,17 +109,20 @@ func Round(x float64) float64 {
 
 // MinMax returns the smallest and the largest value among the provided values.
 // Returns (0, 0) if there are no values.
-// Ignores NaN values.
+// Ignores NaN values. Allowing NaN values could led in a corner case where all
+// values can be NaN, in this case the function will return NaN as min and max.
 func MinMax(values []float64) (min, max float64) {
 	if len(values) == 0 {
 		return 0, 0
 	}
 	min = math.MaxFloat64
 	max = -1 * math.MaxFloat64
+	allNaN := true
 	for _, v := range values {
 		if math.IsNaN(v) {
 			continue
 		}
+		allNaN = false
 
 		if v < min {
 			min = v
@@ -128,6 +131,11 @@ func MinMax(values []float64) (min, max float64) {
 			max = v
 		}
 	}
+
+	if allNaN {
+		return math.NaN(), math.NaN()
+	}
+
 	return min, max
 }
 

--- a/internal/numbers/numbers_test.go
+++ b/internal/numbers/numbers_test.go
@@ -221,12 +221,23 @@ func TestMinMax(t *testing.T) {
 			wantMin: -11.3,
 			wantMax: 22.5,
 		},
+		{
+			desc:    "all NaN values",
+			values:  []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+			wantMin: math.NaN(),
+			wantMax: math.NaN(),
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			gotMin, gotMax := MinMax(tc.values)
-			if gotMin != tc.wantMin || gotMax != tc.wantMax {
+			// Different assertion for NaN cases.
+			if (math.IsNaN(tc.wantMin) && !math.IsNaN(gotMin)) ||
+				(math.IsNaN(tc.wantMax) && !math.IsNaN(gotMax)) {
+				t.Errorf("MinMax => (%v, %v), want (%v, %v)", gotMin, gotMax, tc.wantMin, tc.wantMax)
+			} else if !math.IsNaN(tc.wantMin) && gotMin != tc.wantMin ||
+				!math.IsNaN(tc.wantMax) && gotMax != tc.wantMax {
 				t.Errorf("MinMax => (%v, %v), want (%v, %v)", gotMin, gotMax, tc.wantMin, tc.wantMax)
 			}
 		})

--- a/internal/numbers/numbers_test.go
+++ b/internal/numbers/numbers_test.go
@@ -215,6 +215,12 @@ func TestMinMax(t *testing.T) {
 			wantMin: -11.3,
 			wantMax: 22.5,
 		},
+		{
+			desc:    "min and max among negative, positive, zero and NaN values",
+			values:  []float64{1.1, 0, 1.3, math.NaN(), -11.3, 22.5},
+			wantMin: -11.3,
+			wantMax: 22.5,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/numbers/numbers_test.go
+++ b/internal/numbers/numbers_test.go
@@ -232,13 +232,11 @@ func TestMinMax(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			gotMin, gotMax := MinMax(tc.values)
-			// Different assertion for NaN cases.
-			if (math.IsNaN(tc.wantMin) && !math.IsNaN(gotMin)) ||
-				(math.IsNaN(tc.wantMax) && !math.IsNaN(gotMax)) {
-				t.Errorf("MinMax => (%v, %v), want (%v, %v)", gotMin, gotMax, tc.wantMin, tc.wantMax)
-			} else if !math.IsNaN(tc.wantMin) && gotMin != tc.wantMin ||
-				!math.IsNaN(tc.wantMax) && gotMax != tc.wantMax {
-				t.Errorf("MinMax => (%v, %v), want (%v, %v)", gotMin, gotMax, tc.wantMin, tc.wantMax)
+			if diff := pretty.Compare(tc.wantMin, gotMin); diff != "" {
+				t.Errorf("MinMax => unexpected min, diff (-want, +got):\n %s", diff)
+			}
+			if diff := pretty.Compare(tc.wantMax, gotMax); diff != "" {
+				t.Errorf("MinMax => unexpected max, diff (-want, +got):\n %s", diff)
 			}
 		})
 	}

--- a/widgets/linechart/linechart.go
+++ b/widgets/linechart/linechart.go
@@ -57,7 +57,7 @@ func newSeriesValues(values []float64) *seriesValues {
 	v := make([]float64, len(values))
 	copy(v, values)
 
-	min, max := numbers.MinMax(v)
+	min, max := minMax(v)
 	return &seriesValues{
 		values: v,
 		min:    min,
@@ -176,8 +176,9 @@ func (lc *LineChart) yMinMax() (float64, float64) {
 		maximums = append(maximums, lc.opts.yAxisCustomScale.max)
 	}
 
-	min, _ := numbers.MinMax(minimums)
-	_, max := numbers.MinMax(maximums)
+	min, _ := minMax(minimums)
+	_, max := minMax(maximums)
+
 	return min, max
 }
 
@@ -529,4 +530,23 @@ func (lc *LineChart) maxXValue() int {
 		return 0
 	}
 	return maxLen - 1
+}
+
+const (
+	defMin = 0
+	defMax = 0
+)
+
+// minMax is a wrapper around numbers.MinMax that controls
+// the output if the values are NaN and sets defaults if it's
+// the case.
+func minMax(values []float64) (x, y float64) {
+	min, max := numbers.MinMax(values)
+	if math.IsNaN(min) {
+		min = defMin
+	}
+	if math.IsNaN(max) {
+		max = defMax
+	}
+	return min, max
 }

--- a/widgets/linechart/linechart.go
+++ b/widgets/linechart/linechart.go
@@ -532,21 +532,16 @@ func (lc *LineChart) maxXValue() int {
 	return maxLen - 1
 }
 
-const (
-	defMin = 0
-	defMax = 0
-)
-
 // minMax is a wrapper around numbers.MinMax that controls
 // the output if the values are NaN and sets defaults if it's
 // the case.
 func minMax(values []float64) (x, y float64) {
 	min, max := numbers.MinMax(values)
 	if math.IsNaN(min) {
-		min = defMin
+		min = 0
 	}
 	if math.IsNaN(max) {
-		max = defMax
+		max = 0
 	}
 	return min, max
 }

--- a/widgets/linechart/linechart_test.go
+++ b/widgets/linechart/linechart_test.go
@@ -961,6 +961,53 @@ func TestLineChartDraws(t *testing.T) {
 			},
 		},
 		{
+			desc:   "more values than capacity, X rescales with NaN values ignored",
+			canvas: image.Rect(0, 0, 11, 10),
+			writes: func(lc *LineChart) error {
+				return lc.Series("first", []float64{0, 1, 2, 3, 4, 5, 6, 7, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 12, 13, 14, 15, 16, 17, 18, 19})
+			},
+			wantCapacity: 12,
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+
+				// Y and X axis.
+				lines := []draw.HVLine{
+					{Start: image.Point{4, 0}, End: image.Point{4, 8}},
+					{Start: image.Point{4, 8}, End: image.Point{10, 8}},
+				}
+				testdraw.MustHVLines(c, lines)
+
+				// Value labels.
+				testdraw.MustText(c, "0", image.Point{3, 7})
+				testdraw.MustText(c, "9.92", image.Point{0, 3})
+				testdraw.MustText(c, "0", image.Point{5, 9})
+				testdraw.MustText(c, "14", image.Point{9, 9})
+
+				// Braille line.
+				graphAr := image.Rect(5, 0, 11, 8)
+				bc := testbraille.MustNew(graphAr)
+				testdraw.MustBrailleLine(bc, image.Point{0, 31}, image.Point{1, 29})
+				testdraw.MustBrailleLine(bc, image.Point{1, 29}, image.Point{1, 28})
+				testdraw.MustBrailleLine(bc, image.Point{1, 28}, image.Point{2, 26})
+				testdraw.MustBrailleLine(bc, image.Point{2, 26}, image.Point{2, 25})
+				testdraw.MustBrailleLine(bc, image.Point{2, 25}, image.Point{3, 23})
+				testdraw.MustBrailleLine(bc, image.Point{3, 23}, image.Point{3, 21})
+				testdraw.MustBrailleLine(bc, image.Point{3, 21}, image.Point{4, 20})
+				testdraw.MustBrailleLine(bc, image.Point{7, 12}, image.Point{8, 10})
+				testdraw.MustBrailleLine(bc, image.Point{8, 10}, image.Point{8, 8})
+				testdraw.MustBrailleLine(bc, image.Point{8, 8}, image.Point{9, 7})
+				testdraw.MustBrailleLine(bc, image.Point{9, 7}, image.Point{9, 5})
+				testdraw.MustBrailleLine(bc, image.Point{9, 5}, image.Point{10, 4})
+				testdraw.MustBrailleLine(bc, image.Point{10, 4}, image.Point{10, 2})
+				testdraw.MustBrailleLine(bc, image.Point{10, 2}, image.Point{11, 0})
+				testbraille.MustCopyTo(bc, c)
+
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
 			desc: "more values than capacity, X unscaled",
 			opts: []Option{
 				XAxisUnscaled(),

--- a/widgets/linechart/linechart_test.go
+++ b/widgets/linechart/linechart_test.go
@@ -961,53 +961,6 @@ func TestLineChartDraws(t *testing.T) {
 			},
 		},
 		{
-			desc:   "more values than capacity, X rescales with NaN values ignored",
-			canvas: image.Rect(0, 0, 11, 10),
-			writes: func(lc *LineChart) error {
-				return lc.Series("first", []float64{0, 1, 2, 3, 4, 5, 6, 7, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 12, 13, 14, 15, 16, 17, 18, 19})
-			},
-			wantCapacity: 12,
-			want: func(size image.Point) *faketerm.Terminal {
-				ft := faketerm.MustNew(size)
-				c := testcanvas.MustNew(ft.Area())
-
-				// Y and X axis.
-				lines := []draw.HVLine{
-					{Start: image.Point{4, 0}, End: image.Point{4, 8}},
-					{Start: image.Point{4, 8}, End: image.Point{10, 8}},
-				}
-				testdraw.MustHVLines(c, lines)
-
-				// Value labels.
-				testdraw.MustText(c, "0", image.Point{3, 7})
-				testdraw.MustText(c, "9.92", image.Point{0, 3})
-				testdraw.MustText(c, "0", image.Point{5, 9})
-				testdraw.MustText(c, "14", image.Point{9, 9})
-
-				// Braille line.
-				graphAr := image.Rect(5, 0, 11, 8)
-				bc := testbraille.MustNew(graphAr)
-				testdraw.MustBrailleLine(bc, image.Point{0, 31}, image.Point{1, 29})
-				testdraw.MustBrailleLine(bc, image.Point{1, 29}, image.Point{1, 28})
-				testdraw.MustBrailleLine(bc, image.Point{1, 28}, image.Point{2, 26})
-				testdraw.MustBrailleLine(bc, image.Point{2, 26}, image.Point{2, 25})
-				testdraw.MustBrailleLine(bc, image.Point{2, 25}, image.Point{3, 23})
-				testdraw.MustBrailleLine(bc, image.Point{3, 23}, image.Point{3, 21})
-				testdraw.MustBrailleLine(bc, image.Point{3, 21}, image.Point{4, 20})
-				testdraw.MustBrailleLine(bc, image.Point{7, 12}, image.Point{8, 10})
-				testdraw.MustBrailleLine(bc, image.Point{8, 10}, image.Point{8, 8})
-				testdraw.MustBrailleLine(bc, image.Point{8, 8}, image.Point{9, 7})
-				testdraw.MustBrailleLine(bc, image.Point{9, 7}, image.Point{9, 5})
-				testdraw.MustBrailleLine(bc, image.Point{9, 5}, image.Point{10, 4})
-				testdraw.MustBrailleLine(bc, image.Point{10, 4}, image.Point{10, 2})
-				testdraw.MustBrailleLine(bc, image.Point{10, 2}, image.Point{11, 0})
-				testbraille.MustCopyTo(bc, c)
-
-				testcanvas.MustApply(c, ft)
-				return ft
-			},
-		},
-		{
 			desc: "more values than capacity, X unscaled",
 			opts: []Option{
 				XAxisUnscaled(),
@@ -1568,6 +1521,119 @@ func TestLineChartDraws(t *testing.T) {
 				graphAr := image.Rect(6, 0, 20, 8)
 				bc := testbraille.MustNew(graphAr)
 				testdraw.MustBrailleLine(bc, image.Point{0, 31}, image.Point{26, 0})
+				testbraille.MustCopyTo(bc, c)
+
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "all NaN values",
+			canvas: image.Rect(0, 0, 20, 10),
+			writes: func(lc *LineChart) error {
+				return lc.Series("first", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()})
+			},
+			wantCapacity: 36,
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+
+				// Y and X axis.
+				lines := []draw.HVLine{
+					{Start: image.Point{1, 0}, End: image.Point{1, 8}},
+					{Start: image.Point{1, 8}, End: image.Point{19, 8}},
+				}
+				testdraw.MustHVLines(c, lines)
+
+				// Value labels.
+				testdraw.MustText(c, "0", image.Point{0, 7})
+				testdraw.MustText(c, "0", image.Point{2, 9})
+				testdraw.MustText(c, "1", image.Point{6, 9})
+				testdraw.MustText(c, "2", image.Point{10, 9})
+				testdraw.MustText(c, "3", image.Point{14, 9})
+				testdraw.MustText(c, "4", image.Point{18, 9})
+
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "first and last NaN values",
+			canvas: image.Rect(0, 0, 28, 10),
+			writes: func(lc *LineChart) error {
+				return lc.Series("first", []float64{math.NaN(), math.NaN(), 100, 150, math.NaN()})
+			},
+			wantCapacity: 44,
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+
+				// Y and X axis.
+				lines := []draw.HVLine{
+					{Start: image.Point{5, 0}, End: image.Point{5, 8}},
+					{Start: image.Point{5, 8}, End: image.Point{27, 8}},
+				}
+				testdraw.MustHVLines(c, lines)
+
+				// Value labels.
+				testdraw.MustText(c, "0", image.Point{4, 7})
+				testdraw.MustText(c, "77.44", image.Point{0, 3})
+				testdraw.MustText(c, "0", image.Point{6, 9})
+				testdraw.MustText(c, "1", image.Point{11, 9})
+				testdraw.MustText(c, "2", image.Point{16, 9})
+				testdraw.MustText(c, "3", image.Point{22, 9})
+				testdraw.MustText(c, "4", image.Point{27, 9})
+
+				graphAr := image.Rect(6, 0, 25, 8)
+				bc := testbraille.MustNew(graphAr)
+				testdraw.MustBrailleLine(bc, image.Point{21, 10}, image.Point{32, 0})
+				testbraille.MustCopyTo(bc, c)
+
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "more values than capacity, X rescales with NaN values ignored",
+			canvas: image.Rect(0, 0, 11, 10),
+			writes: func(lc *LineChart) error {
+				return lc.Series("first", []float64{0, 1, 2, 3, 4, 5, 6, 7, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 12, 13, 14, 15, 16, 17, 18, 19})
+			},
+			wantCapacity: 12,
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+
+				// Y and X axis.
+				lines := []draw.HVLine{
+					{Start: image.Point{4, 0}, End: image.Point{4, 8}},
+					{Start: image.Point{4, 8}, End: image.Point{10, 8}},
+				}
+				testdraw.MustHVLines(c, lines)
+
+				// Value labels.
+				testdraw.MustText(c, "0", image.Point{3, 7})
+				testdraw.MustText(c, "9.92", image.Point{0, 3})
+				testdraw.MustText(c, "0", image.Point{5, 9})
+				testdraw.MustText(c, "14", image.Point{9, 9})
+
+				// Braille line.
+				graphAr := image.Rect(5, 0, 11, 8)
+				bc := testbraille.MustNew(graphAr)
+				testdraw.MustBrailleLine(bc, image.Point{0, 31}, image.Point{1, 29})
+				testdraw.MustBrailleLine(bc, image.Point{1, 29}, image.Point{1, 28})
+				testdraw.MustBrailleLine(bc, image.Point{1, 28}, image.Point{2, 26})
+				testdraw.MustBrailleLine(bc, image.Point{2, 26}, image.Point{2, 25})
+				testdraw.MustBrailleLine(bc, image.Point{2, 25}, image.Point{3, 23})
+				testdraw.MustBrailleLine(bc, image.Point{3, 23}, image.Point{3, 21})
+				testdraw.MustBrailleLine(bc, image.Point{3, 21}, image.Point{4, 20})
+				testdraw.MustBrailleLine(bc, image.Point{7, 12}, image.Point{8, 10})
+				testdraw.MustBrailleLine(bc, image.Point{8, 10}, image.Point{8, 8})
+				testdraw.MustBrailleLine(bc, image.Point{8, 8}, image.Point{9, 7})
+				testdraw.MustBrailleLine(bc, image.Point{9, 7}, image.Point{9, 5})
+				testdraw.MustBrailleLine(bc, image.Point{9, 5}, image.Point{10, 4})
+				testdraw.MustBrailleLine(bc, image.Point{10, 4}, image.Point{10, 2})
+				testdraw.MustBrailleLine(bc, image.Point{10, 2}, image.Point{11, 0})
 				testbraille.MustCopyTo(bc, c)
 
 				testcanvas.MustApply(c, ft)


### PR DESCRIPTION
This PR Fixes #184.

It will allow having _values_ on the line chart that will not be displayed if they are missing. To do so it will use the `math.NaN` float64 value.

If this is combined with adaptive Y-axis option, the graphs that have empty gaps and high values with small variance will be more accurate regarding the Y axis (because they will not start at 0).

In this example, we can see that we don't have metrics around 10:03-10:05 making the graph render values as 0 and making Y axis start at 0:

![](https://i.imgur.com/Gs4qaoz.png)

Instead of representing the missing metrics as 0, with this change and using `math.NaN`, the Y axis has a better range around the min and max values making the graph more accurate.

![](https://i.imgur.com/K1kgapF.png)