### PR TITLE
Guarantee some spacing between donut and its label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `Donut` widget now guarantees spacing between the donut and its label.
+
 ## [0.9.0] - 28-Apr-2019
 
 ### Added

--- a/widgets/donut/donut.go
+++ b/widgets/donut/donut.go
@@ -196,7 +196,7 @@ func (d *Donut) drawText(cvs *canvas.Canvas, donutAr image.Rectangle, mid image.
 
 // drawLabel draws the text label in the area.
 func (d *Donut) drawLabel(cvs *canvas.Canvas, labelAr image.Rectangle) error {
-	start, err := alignfor.Text(labelAr, d.opts.label, d.opts.labelAlign, align.VerticalMiddle)
+	start, err := alignfor.Text(labelAr, d.opts.label, d.opts.labelAlign, align.VerticalBottom)
 	if err != nil {
 		return err
 	}
@@ -310,20 +310,14 @@ func (d *Donut) Options() widgetapi.Options {
 	}
 }
 
-// donutAndLabel splits the canvas area into square area for the donut and an
+// donutAndLabel splits the canvas area into an area for the donut and an
 // area under the donut for the text label.
 func donutAndLabel(cvsAr image.Rectangle) (donAr, labelAr image.Rectangle, err error) {
 	height := cvsAr.Dy()
-	// One line for the text label at the bottom.
-	top, labelAr, err := area.HSplitCells(cvsAr, height-1)
-	if err != nil {
-		return image.ZR, image.ZR, err
-	}
-
-	// Remove one line from the top too so the donut area remains square.
-	// When using braille, this effectively removes 4 pixels from both the top
-	// and the bottom. See braille.RowMult.
-	donAr, err = area.Shrink(top, 1, 0, 0, 0)
+	// Two lines for the text label at the bottom.
+	// One for the text itself and one for visual space between the donut and
+	// the label.
+	donAr, labelAr, err = area.HSplitCells(cvsAr, height-2)
 	if err != nil {
 		return image.ZR, image.ZR, err
 	}

--- a/widgets/donut/donut.go
+++ b/widgets/donut/donut.go
@@ -167,8 +167,7 @@ func (d *Donut) holeRadius(donutRadius int) int {
 // The text is only drawn if the radius of the donut "hole" is large enough to
 // accommodate it.
 // The mid point addresses coordinates in pixels on a braille canvas.
-// The donutAr is the cell area for the donut itself.
-func (d *Donut) drawText(cvs *canvas.Canvas, donutAr image.Rectangle, mid image.Point, holeR int) error {
+func (d *Donut) drawText(cvs *canvas.Canvas, mid image.Point, holeR int) error {
 	cells, first := availableCells(mid, holeR)
 	t := d.progressText()
 	needCells := runewidth.StringWidth(t)
@@ -176,13 +175,6 @@ func (d *Donut) drawText(cvs *canvas.Canvas, donutAr image.Rectangle, mid image.
 		return nil
 	}
 
-	if donutAr.Min.Y > 0 {
-		// donutAr is what the braille canvas is created from, mid is relative
-		// to it.
-		// donutAr might have non-zero Y coordinate if we are displaying a text
-		// label.
-		first.Y += donutAr.Min.Y
-	}
 	ar := image.Rect(first.X, first.Y, first.X+cells+2, first.Y+1)
 	start, err := alignfor.Text(ar, t, align.HorizontalCenter, align.VerticalMiddle)
 	if err != nil {
@@ -270,7 +262,7 @@ func (d *Donut) Draw(cvs *canvas.Canvas, meta *widgetapi.Meta) error {
 	}
 
 	if !d.opts.hideTextProgress {
-		if err := d.drawText(cvs, donutAr, mid, holeR); err != nil {
+		if err := d.drawText(cvs, mid, holeR); err != nil {
 			return err
 		}
 	}

--- a/widgets/donut/donut_test.go
+++ b/widgets/donut/donut_test.go
@@ -338,8 +338,8 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(ft.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 3,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 3,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
@@ -642,14 +642,14 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(c.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 6, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 6, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
 				testbraille.MustCopyTo(bc, c)
 
-				testdraw.MustText(c, "100%", image.Point{2, 3})
+				testdraw.MustText(c, "100%", image.Point{2, 2})
 
 				testdraw.MustText(c, "hi", image.Point{2, 6})
 
@@ -672,14 +672,14 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(c.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 6, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 6, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
 				testbraille.MustCopyTo(bc, c)
 
-				testdraw.MustText(c, "100%", image.Point{2, 3})
+				testdraw.MustText(c, "100%", image.Point{2, 2})
 
 				testdraw.MustText(c, "hi", image.Point{2, 6})
 
@@ -702,14 +702,14 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(c.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 6, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 6, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
 				testbraille.MustCopyTo(bc, c)
 
-				testdraw.MustText(c, "100%", image.Point{2, 3})
+				testdraw.MustText(c, "100%", image.Point{2, 2})
 
 				testdraw.MustText(c, "hi", image.Point{0, 6})
 
@@ -732,14 +732,14 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(c.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 6, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 6, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
 				testbraille.MustCopyTo(bc, c)
 
-				testdraw.MustText(c, "100%", image.Point{2, 3})
+				testdraw.MustText(c, "100%", image.Point{2, 2})
 
 				testdraw.MustText(c, "hi", image.Point{5, 6})
 
@@ -765,14 +765,14 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(c.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 6, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 6, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
 				testbraille.MustCopyTo(bc, c)
 
-				testdraw.MustText(c, "100%", image.Point{2, 3})
+				testdraw.MustText(c, "100%", image.Point{2, 2})
 
 				testdraw.MustText(
 					c,
@@ -804,14 +804,14 @@ func TestDonut(t *testing.T) {
 				c := testcanvas.MustNew(ft.Area())
 				bc := testbraille.MustNew(c.Area())
 
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 6, draw.BrailleCircleFilled())
-				testdraw.MustBrailleCircle(bc, image.Point{6, 13}, 5,
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 6, draw.BrailleCircleFilled())
+				testdraw.MustBrailleCircle(bc, image.Point{6, 9}, 5,
 					draw.BrailleCircleFilled(),
 					draw.BrailleCircleClearPixels(),
 				)
 				testbraille.MustCopyTo(bc, c)
 
-				testdraw.MustText(c, "100%", image.Point{2, 3})
+				testdraw.MustText(c, "100%", image.Point{2, 2})
 
 				testdraw.MustText(c, "hello …", image.Point{0, 6})
 

--- a/widgets/donut/donutdemo/donutdemo.go
+++ b/widgets/donut/donutdemo/donutdemo.go
@@ -50,7 +50,7 @@ func playDonut(ctx context.Context, d *donut.Donut, start, step int, delay time.
 		case <-ticker.C:
 			switch pt {
 			case playTypePercent:
-				if err := d.Percent(100); err != nil {
+				if err := d.Percent(progress); err != nil {
 					panic(err)
 				}
 			case playTypeAbsolute:
@@ -117,22 +117,20 @@ func main() {
 		t,
 		container.Border(linestyle.Light),
 		container.BorderTitle("PRESS Q TO QUIT"),
-		container.PlaceWidget(green),
-		/*
-			container.SplitVertical(
-				container.Left(
-					container.SplitVertical(
-						container.Left(container.PlaceWidget(green)),
-						container.Right(container.PlaceWidget(blue)),
-					),
+		container.SplitVertical(
+			container.Left(
+				container.SplitVertical(
+					container.Left(container.PlaceWidget(green)),
+					container.Right(container.PlaceWidget(blue)),
 				),
-				container.Right(
-					container.SplitVertical(
-						container.Left(container.PlaceWidget(yellow)),
-						container.Right(container.PlaceWidget(red)),
-					),
+			),
+			container.Right(
+				container.SplitVertical(
+					container.Left(container.PlaceWidget(yellow)),
+					container.Right(container.PlaceWidget(red)),
 				),
-			),*/
+			),
+		),
 	)
 	if err != nil {
 		panic(err)

--- a/widgets/donut/donutdemo/donutdemo.go
+++ b/widgets/donut/donutdemo/donutdemo.go
@@ -50,7 +50,7 @@ func playDonut(ctx context.Context, d *donut.Donut, start, step int, delay time.
 		case <-ticker.C:
 			switch pt {
 			case playTypePercent:
-				if err := d.Percent(progress); err != nil {
+				if err := d.Percent(100); err != nil {
 					panic(err)
 				}
 			case playTypeAbsolute:
@@ -117,20 +117,22 @@ func main() {
 		t,
 		container.Border(linestyle.Light),
 		container.BorderTitle("PRESS Q TO QUIT"),
-		container.SplitVertical(
-			container.Left(
-				container.SplitVertical(
-					container.Left(container.PlaceWidget(green)),
-					container.Right(container.PlaceWidget(blue)),
+		container.PlaceWidget(green),
+		/*
+			container.SplitVertical(
+				container.Left(
+					container.SplitVertical(
+						container.Left(container.PlaceWidget(green)),
+						container.Right(container.PlaceWidget(blue)),
+					),
 				),
-			),
-			container.Right(
-				container.SplitVertical(
-					container.Left(container.PlaceWidget(yellow)),
-					container.Right(container.PlaceWidget(red)),
+				container.Right(
+					container.SplitVertical(
+						container.Left(container.PlaceWidget(yellow)),
+						container.Right(container.PlaceWidget(red)),
+					),
 				),
-			),
-		),
+			),*/
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Gives at least one empty line under the donut and above the text label.

Updates #85 