### PR TITLE
Change MaxUint32 to MaxInt32 in scroll.go

### DIFF
--- a/widgets/text/scroll.go
+++ b/widgets/text/scroll.go
@@ -116,7 +116,7 @@ func rollToEnd(st *scrollTracker, lines, height int) rollState {
 	// If the user didn't scroll, just roll the content so that the last line
 	// is visible.
 	if st.scroll == 0 && st.scrollPage == 0 {
-		st.first = normalizeScroll(math.MaxUint32, lines, height)
+		st.first = normalizeScroll(math.MaxInt32, lines, height)
 		return rollToEnd
 	}
 


### PR DESCRIPTION
This change addresses the following compile error, reported by raspberry-pi golang compiler v1.12:

/home/pi/go/pkg/mod/github.com/mum4k/termdash@v0.9.0/widgets/text/scroll.go:119:29: constant 4294967295 overflows int