### PR TITLE
Advancing CI to Go 1.14.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-        - 1.10.x
         - 1.11.x
         - 1.12.x
+        - 1.13.x
         - stable
 script:
         - go get -t ./...

--- a/internal/numbers/numbers_test.go
+++ b/internal/numbers/numbers_test.go
@@ -83,8 +83,7 @@ func TestZeroBeforeDecimal(t *testing.T) {
 	}
 }
 
-// Copied from the math package of Go 1.10 for backwards compatibility with Go
-// 1.8 where the math.Round function doesn't exist yet.
+// Copied from the Go's math package, file all_test.go.
 func tolerance(a, b, e float64) bool {
 	// Multiplying by e here can underflow denormal values to zero.
 	// Check a==b so that at least if a and b are small and identical
@@ -107,18 +106,7 @@ func tolerance(a, b, e float64) bool {
 	}
 	return d < e
 }
-func close(a, b float64) bool      { return tolerance(a, b, 1e-14) }
-func veryclose(a, b float64) bool  { return tolerance(a, b, 4e-16) }
-func soclose(a, b, e float64) bool { return tolerance(a, b, e) }
-func alike(a, b float64) bool {
-	switch {
-	case math.IsNaN(a) && math.IsNaN(b):
-		return true
-	case a == b:
-		return math.Signbit(a) == math.Signbit(b)
-	}
-	return false
-}
+func veryclose(a, b float64) bool { return tolerance(a, b, 4e-16) }
 
 func TestMinMax(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
- Updating a comment that was incorrectly indicating that test functions were related to Go 1.10.