### PR TITLE
Release v0.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 go:
-        - 1.11.x
-        - 1.12.x
-        - 1.13.x
+        - 1.14.x
+        - 1.15.x
         - stable
 script:
         - go get -t ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,7 +341,8 @@ identifiers shouldn't be used externally.
 - The Gauge widget.
 - The Text widget.
 
-[unreleased]: https://github.com/mum4k/termdash/compare/v0.12.1...devel
+[unreleased]: https://github.com/mum4k/termdash/compare/v0.12.2...devel
+[0.12.2]: https://github.com/mum4k/termdash/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/mum4k/termdash/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/mum4k/termdash/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mum4k/termdash/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 31-Aug-2020
+
+### Fixed
+
+- advanced the CI Go versions up to Go 1.15.
+- fixed the build status badge to correctly point to travis-ci.com instead of
+  travis-ci.org.
+
 ## [0.12.1] - 20-Jun-2020
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Doc Status](https://godoc.org/github.com/mum4k/termdash?status.png)](https://godoc.org/github.com/mum4k/termdash)
-[![Build Status](https://travis-ci.org/mum4k/termdash.svg?branch=master)](https://travis-ci.org/mum4k/termdash)
+[![Build Status](https://travis-ci.com/mum4k/termdash.svg?branch=master)](https://travis-ci.com/mum4k/termdash)
 [![Sourcegraph](https://sourcegraph.com/github.com/mum4k/termdash/-/badge.svg)](https://sourcegraph.com/github.com/mum4k/termdash?badge)
 [![Coverage Status](https://coveralls.io/repos/github/mum4k/termdash/badge.svg?branch=master)](https://coveralls.io/github/mum4k/termdash?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mum4k/termdash)](https://goreportcard.com/report/github.com/mum4k/termdash)


### PR DESCRIPTION
# v0.12.2 - 31-Aug-2020

### Fixed

- advanced the CI Go versions up to Go 1.15.
- fixed the build status badge to correctly point to travis-ci.com instead of
  travis-ci.org.