### PR TITLE
Ability to swap scrolling runes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Termdash uses [this branching model](https://nvie.com/posts/a-successful-git-bra
 - [datadash](https://github.com/keithknott26/datadash): Visualize streaming or tabular data inside the terminal.
 - [grafterm](https://github.com/slok/grafterm): Metrics dashboards visualization on the terminal.
 - [perfstat](https://github.com/flaviostutz/perfstat): Analyze and show tips about possible bottlenecks in Linux systems.
+- [gex](https://github.com/Tosch110/gex): Cosmos SDK explorer in-terminal.
 
 # Disclaimer
 

--- a/widgets/text/options.go
+++ b/widgets/text/options.go
@@ -32,6 +32,8 @@ type Option interface {
 
 // options stores the provided options.
 type options struct {
+	scrollUp	 rune
+	scrollDown	 rune
 	wrapMode         wrap.Mode
 	rollContent      bool
 	disableScrolling bool
@@ -46,6 +48,8 @@ type options struct {
 // newOptions returns a new options instance.
 func newOptions(opts ...Option) *options {
 	opt := &options{
+		scrollUp: 	 DefaultScrollUpRune,
+		scrollDown: 	 DefaultScrollDownRune,
 		mouseUpButton:   DefaultScrollMouseButtonUp,
 		mouseDownButton: DefaultScrollMouseButtonDown,
 		keyUp:           DefaultScrollKeyUp,
@@ -83,6 +87,22 @@ type option func(*options)
 func (o option) set(opts *options) {
 	o(opts)
 }
+
+// ScrollRunes configures the text widgets scroll runes, shown at the top and
+// bottom of a scrollable text widget. If not provided, the default scroll
+// runes will be used.
+func ScrollRunes(up, down rune) Option {
+	return option(func(opts *options) {
+		opts.scrollUp = up
+		opts.scrollDown = down
+	})
+}
+
+// The default scroll runes for content scrolling
+const (
+	DefaultScrollUpRune = '⇧'
+	DefaultScrollDownRune = '⇩'
+)
 
 // WrapAtWords configures the text widget so that it automatically wraps lines
 // that are longer than the width of the widget at word boundaries. If not

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -125,7 +125,7 @@ const minLinesForMarkers = 3
 func (t *Text) drawScrollUp(cvs *canvas.Canvas, cur image.Point, fromLine int) (bool, error) {
 	height := cvs.Area().Dy()
 	if cur.Y == 0 && height >= minLinesForMarkers && fromLine > 0 {
-		cells, err := cvs.SetCell(cur, '⇧')
+		cells, err := cvs.SetCell(cur, t.opts.scrollUp)
 		if err != nil {
 			return false, err
 		}
@@ -144,7 +144,7 @@ func (t *Text) drawScrollDown(cvs *canvas.Canvas, cur image.Point, fromLine int)
 	height := cvs.Area().Dy()
 	lines := len(t.wrapped)
 	if cur.Y == height-1 && height >= minLinesForMarkers && height < lines-fromLine {
-		cells, err := cvs.SetCell(cur, '⇩')
+		cells, err := cvs.SetCell(cur, t.opts.scrollDown)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
#245 fixes this issue with windows consoles by adding option to switch the scroll runes on a text widget.
The option `text.ScrollRunes` accepts two rune parameters, up and down, the default runes are the same `⇧` and `⇩`.

An example of this which will draw correct scroll runes on windows
`text.New(text.RollContent(), text.WrapAtWords(), text.ScrollRunes('▲', '▼'))`