### PR TITLE
Ability to move focus using keyboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ability to configure keyboard keys that move focus to the next or the
+  previous container.
+
 ## [0.13.0] - 17-Nov-2020
 
 ### Added

--- a/container/container.go
+++ b/container/container.go
@@ -327,9 +327,13 @@ func (c *Container) prepareEvTargets(ev terminalapi.Event) (func() error, error)
 		}, nil
 
 	case *terminalapi.Keyboard:
-		c.updateFocusFromKeyboard(ev.(*terminalapi.Keyboard))
-
 		targets := c.keyEvTargets()
+
+		// Update the focused container based on the pressed key.
+		// Done after collecting "targets" above. If the key changes which
+		// widget is focused, they key press itself should go to the widget
+		// that was focused when the key was pressed.
+		c.updateFocusFromKeyboard(ev.(*terminalapi.Keyboard))
 		return func() error {
 			for _, w := range targets {
 				if err := w.Keyboard(e); err != nil {

--- a/container/container.go
+++ b/container/container.go
@@ -278,8 +278,11 @@ func (c *Container) updateFocusFromMouse(m *terminalapi.Mouse) {
 // changes the focused container.
 // Caller must hold c.mu.
 func (c *Container) updateFocusFromKeyboard(k *terminalapi.Keyboard) {
-	if c.opts.global.keyFocusNext != nil && *c.opts.global.keyFocusNext == k.Key {
+	switch {
+	case c.opts.global.keyFocusNext != nil && *c.opts.global.keyFocusNext == k.Key:
 		c.focusTracker.next()
+	case c.opts.global.keyFocusPrevious != nil && *c.opts.global.keyFocusPrevious == k.Key:
+		c.focusTracker.previous()
 	}
 }
 

--- a/container/focus_test.go
+++ b/container/focus_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/mum4k/termdash/cell"
+	"github.com/mum4k/termdash/keyboard"
 	"github.com/mum4k/termdash/linestyle"
 	"github.com/mum4k/termdash/mouse"
 	"github.com/mum4k/termdash/private/event"
@@ -418,6 +419,222 @@ func TestFocusTrackerMouse(t *testing.T) {
 			if err := root.Draw(); err != nil {
 				t.Fatalf("Draw => unexpected error: %v", err)
 			}
+			for _, ev := range tc.events {
+				eds.Event(ev)
+			}
+			if err := testevent.WaitFor(5*time.Second, func() error {
+				if got, want := eds.Processed(), tc.wantProcessed; got != want {
+					return fmt.Errorf("the event distribution system processed %d events, want %d", got, want)
+				}
+				return nil
+			}); err != nil {
+				t.Fatalf("testevent.WaitFor => %v", err)
+			}
+
+			var wantFocused *Container
+			switch wf := tc.wantFocused; wf {
+			case contLocRoot:
+				wantFocused = root
+			case contLocLeft:
+				wantFocused = root.first
+			case contLocRight:
+				wantFocused = root.second
+			default:
+				t.Fatalf("unsupported wantFocused value => %v", wf)
+			}
+
+			if !root.focusTracker.isActive(wantFocused) {
+				t.Errorf("isActive(%v) => false, want true, status: root(%v):%v, left(%v):%v, right(%v):%v",
+					tc.wantFocused,
+					contLocRoot, root.focusTracker.isActive(root),
+					contLocLeft, root.focusTracker.isActive(root.first),
+					contLocRight, root.focusTracker.isActive(root.second),
+				)
+			}
+		})
+	}
+}
+
+// contDir represents a direction in which we want to change container focus.
+type contDir int
+
+// String implements fmt.Stringer()
+func (cd contDir) String() string {
+	if n, ok := contDirNames[cd]; ok {
+		return n
+	}
+	return "contDirUnknown"
+}
+
+// contDirNames maps contDir values to human readable names.
+var contDirNames = map[contDir]string{
+	contDirNext:     "contDirNext",
+	contDirPrevious: "contDirPrevious",
+}
+
+const (
+	contDirUnknown contDir = iota
+	contDirNext
+	contDirPrevious
+)
+
+func TestFocusTrackerNextAndPrevious(t *testing.T) {
+	ft, err := faketerm.New(image.Point{10, 10})
+	if err != nil {
+		t.Fatalf("faketerm.New => unexpected error: %v", err)
+	}
+
+	const (
+		keyNext     keyboard.Key = keyboard.KeyTab
+		keyPrevious keyboard.Key = '~'
+	)
+
+	tests := []struct {
+		desc          string
+		container     func(ft *faketerm.Terminal) (*Container, error)
+		events        []*terminalapi.Keyboard
+		wantFocused   contLoc
+		wantProcessed int
+	}{
+		{
+			desc: "initially the root is focused",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusNext(keyNext),
+				)
+			},
+			wantFocused: contLocRoot,
+		},
+		{
+			desc: "keyNext does nothing when only root exists",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusNext(keyNext),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyNext},
+			},
+			wantFocused:   contLocRoot,
+			wantProcessed: 1,
+		},
+		{
+			desc: "keyNext focuses the first container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusNext(keyNext),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyNext},
+			},
+			wantFocused:   contLocLeft,
+			wantProcessed: 1,
+		},
+		{
+			desc: "two keyNext presses focuses the second container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusNext(keyNext),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyNext},
+				{Key: keyNext},
+			},
+			wantFocused:   contLocRight,
+			wantProcessed: 2,
+		},
+		{
+			desc: "three keyNext presses focuses the first container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusNext(keyNext),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyNext},
+				{Key: keyNext},
+				{Key: keyNext},
+			},
+			wantFocused:   contLocLeft,
+			wantProcessed: 3,
+		},
+		{
+			desc: "four keyNext presses focuses the second container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusNext(keyNext),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyNext},
+				{Key: keyNext},
+				{Key: keyNext},
+				{Key: keyNext},
+			},
+			wantFocused:   contLocRight,
+			wantProcessed: 4,
+		},
+		{
+			desc: "five keyNext presses focuses the first container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusNext(keyNext),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyNext},
+				{Key: keyNext},
+				{Key: keyNext},
+				{Key: keyNext},
+				{Key: keyNext},
+			},
+			wantFocused:   contLocLeft,
+			wantProcessed: 5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			root, err := tc.container(ft)
+			if err != nil {
+				t.Fatalf("tc.container => unexpected error: %v", err)
+			}
+
+			eds := event.NewDistributionSystem()
+			root.Subscribe(eds)
 			for _, ev := range tc.events {
 				eds.Event(ev)
 			}

--- a/container/focus_test.go
+++ b/container/focus_test.go
@@ -624,6 +624,120 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantFocused:   contLocLeft,
 			wantProcessed: 5,
 		},
+		{
+			desc: "keyPrevious does nothing when only root exists",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusPrevious(keyPrevious),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyPrevious},
+			},
+			wantFocused:   contLocRoot,
+			wantProcessed: 1,
+		},
+		{
+			desc: "keyPrevious focuses the last container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusPrevious(keyPrevious),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyPrevious},
+			},
+			wantFocused:   contLocRight,
+			wantProcessed: 1,
+		},
+		{
+			desc: "two keyPrevious presses focuses the first container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusPrevious(keyPrevious),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+			},
+			wantFocused:   contLocLeft,
+			wantProcessed: 2,
+		},
+		{
+			desc: "three keyPrevious presses focuses the second container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusPrevious(keyPrevious),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+			},
+			wantFocused:   contLocRight,
+			wantProcessed: 3,
+		},
+		{
+			desc: "four keyPrevious presses focuses the first container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusPrevious(keyPrevious),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+			},
+			wantFocused:   contLocLeft,
+			wantProcessed: 4,
+		},
+		{
+			desc: "five keyPrevious presses focuses the second container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeyFocusPrevious(keyPrevious),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+				{Key: keyPrevious},
+			},
+			wantFocused:   contLocRight,
+			wantProcessed: 5,
+		},
 	}
 
 	for _, tc := range tests {

--- a/container/options.go
+++ b/container/options.go
@@ -842,7 +842,7 @@ func Bottom(opts ...Option) BottomOption {
 // container when pressed.
 //
 // Containers are organized in a binary tree, when the focus moves to the next
-// container, it targets the next leaf container in a DFS traversal.
+// container, it targets the next leaf container in a DFS (Depth-first search) traversal.
 // Non-leaf containers are skipped. If the currently focused container is the
 // last container, the focus moves back to the first container.
 //
@@ -860,7 +860,7 @@ func KeyFocusNext(key keyboard.Key) Option {
 // previous container when pressed.
 //
 // Containers are organized in a binary tree, when the focus moves to the previous
-// container, it targets the previous leaf container in a DFS traversal.
+// container, it targets the previous leaf container in a DFS (Depth-first search) traversal.
 // Non-leaf containers are skipped. If the currently focused container is the
 // first container, the focus moves back to the last container.
 //

--- a/container/options.go
+++ b/container/options.go
@@ -842,13 +842,13 @@ func Bottom(opts ...Option) BottomOption {
 // container when pressed.
 //
 // Containers are organized in a binary tree, when the focus moves to the next
-// container, it targets the next leaf container in a DFS traversal that
-// contains a widget. Non-leaf containers and containers without widgets are
-// skipped. If the currently focused container is the last container, the focus
-// moves back to the first container.
+// container, it targets the next leaf container in a DFS traversal.
+// Non-leaf containers are skipped. If the currently focused container is the
+// last container, the focus moves back to the first container.
 //
 // This option is global and applies to all created containers.
-// If not specified, keyboard the focused container can only be changed by using the mouse.
+// If neither of (KeyFocusNext, KeyFocusPrevious) is specified, the keyboard
+// focus can only be changed by using the mouse.
 func KeyFocusNext(key keyboard.Key) Option {
 	return option(func(c *Container) error {
 		c.opts.global.keyFocusNext = &key
@@ -860,12 +860,13 @@ func KeyFocusNext(key keyboard.Key) Option {
 // previous container when pressed.
 //
 // Containers are organized in a binary tree, when the focus moves to the previous
-// container, it targets the previous leaf container in a DFS traversal that
-// contains a widget. Non-leaf containers and containers without widgets are
-// skipped. If the currently focused container is the first container, the focus
-// moves back to the last container.
+// container, it targets the previous leaf container in a DFS traversal.
+// Non-leaf containers are skipped. If the currently focused container is the
+// first container, the focus moves back to the last container.
 //
 // This option is global and applies to all created containers.
+// If neither of (KeyFocusNext, KeyFocusPrevious) is specified, the keyboard
+// focus can only be changed by using the mouse.
 func KeyFocusPrevious(key keyboard.Key) Option {
 	return option(func(c *Container) error {
 		c.opts.global.keyFocusPrevious = &key

--- a/private/faketerm/diff.go
+++ b/private/faketerm/diff.go
@@ -100,6 +100,9 @@ func Diff(want, got *Terminal) string {
 			for col := 0; col < size.X; col++ {
 				got := got.BackBuffer()[col][row].Rune
 				want := want.BackBuffer()[col][row].Rune
+				if got == want {
+					continue
+				}
 				b.WriteString(fmt.Sprintf("  cell(%v, %v) => got '%c' (rune %d), want '%c' (rune %d)\n", col, row, got, got, want, want))
 			}
 		}


### PR DESCRIPTION
Steps:
- [x] Add `Container` options that configure keys that move focus.
- [x] Enable moving focus to the next container.
- [x] Enable moving focus to the previous container.
- [x] Document the feature in the wiki.

Resolves #243 