### PR TITLE
Send metadata about events to widgets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking API changes
 
-- The `widgetapi.Widget.Keyboard` and `widgetapi.Widget.Mouse` method now
+- The `widgetapi.Widget.Keyboard` and `widgetapi.Widget.Mouse` methods now
   accepts a second argument which provides widgets with additional metadata.
-  This affects all implemented widgets.
+  All widgets implemented outside of the `termdash` repository will need to be
+  similarly to the `Barchart` example below. Change the original method
+  signatures:
+  ```go
+  func (*BarChart) Keyboard(k *terminalapi.Keyboard) error { ... }
+
+  func (*BarChart) Mouse(m *terminalapi.Mouse) error { ... }
+
+  ```
+
+  By adding the new `*widgetapi.EventMeta` argument as follows:
+  ```go
+  func (*BarChart) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error { ... }
+
+  func (*BarChart) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error { ... }
+  ```
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking API changes
+
+- The `widgetapi.Widget.Keyboard` and `widgetapi.Widget.Mouse` method now
+  accepts a second argument which provides widgets with additional metadata.
+  This affects all implemented widgets.
+
 ### Added
 
 - ability to configure keyboard keys that move focus to the next or the

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -1143,7 +1143,10 @@ func TestKeyboard(t *testing.T) {
 					testcanvas.MustNew(image.Rect(20, 10, 40, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
-					&terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1188,7 +1191,10 @@ func TestKeyboard(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 0, 20, 20)),
 					&widgetapi.Meta{},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeGlobal},
-					&terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 
 				// Widget that isn't focused and only wants focused events.
@@ -1205,7 +1211,10 @@ func TestKeyboard(t *testing.T) {
 					testcanvas.MustNew(image.Rect(20, 10, 40, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
-					&terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1412,7 +1421,6 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(25, 10, 50, 20)),
 					&widgetapi.Meta{},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Keyboard{},
 				)
 
 				// The target widget receives the mouse event.
@@ -1421,8 +1429,14 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(25, 0, 50, 10)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{24, 9}, Button: mouse.ButtonLeft},
-					&terminalapi.Mouse{Position: image.Point{24, 9}, Button: mouse.ButtonRelease},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{24, 9}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{24, 9}, Button: mouse.ButtonRelease},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1495,7 +1509,6 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(25, 10, 50, 20)),
 					&widgetapi.Meta{},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Keyboard{},
 				)
 
 				// The target widget receives the mouse event.
@@ -1504,14 +1517,20 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(26, 1, 49, 9)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{22, 7}, Button: mouse.ButtonLeft},
-					&terminalapi.Mouse{Position: image.Point{22, 7}, Button: mouse.ButtonRelease},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{22, 7}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{22, 7}, Button: mouse.ButtonRelease},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
 		},
 		{
-			desc:     "key event focuses the next container, widget with KeyScopeFocused does not get the key as it was not focused yet",
+			desc:     "key event focuses the next container, widget with KeyScopeFocused gets the key as it is now focused",
 			termSize: image.Point{50, 20},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				c, err := New(
@@ -1542,6 +1561,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 0, 25, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				fakewidget.MustDraw(
 					ft,
@@ -1591,6 +1614,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(25, 0, 50, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1627,19 +1654,26 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 0, 25, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				fakewidget.MustDraw(
 					ft,
 					testcanvas.MustNew(image.Rect(25, 0, 50, 20)),
 					&widgetapi.Meta{},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeGlobal},
-					&terminalapi.Keyboard{Key: keyboard.KeyTab},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
 		},
 		{
-			desc:     "key event moves focus from a widget with KeyScopeFocused, the originally focused widget gets the key",
+			desc:     "key event moves focus from a widget with KeyScopeFocused, the newly focused widget gets the key",
 			termSize: image.Point{50, 20},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				c, err := New(
@@ -1673,13 +1707,21 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 0, 25, 20)),
 					&widgetapi.Meta{},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
-					&terminalapi.Keyboard{Key: keyboard.KeyTab},
+					// Also gets the key, since we are sending two events above.
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				fakewidget.MustDraw(
 					ft,
 					testcanvas.MustNew(image.Rect(25, 0, 50, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1774,7 +1816,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(1, 1, 20, 19)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1810,7 +1855,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(1, 1, 20, 19)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1873,7 +1921,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 5, 20, 15)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -1905,7 +1956,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 5, 20, 15)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -2014,7 +2068,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 10, 20, 20)),
 					&widgetapi.Meta{},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -2046,7 +2103,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(0, 5, 20, 15)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -2078,7 +2138,10 @@ func TestMouse(t *testing.T) {
 					testcanvas.MustNew(image.Rect(6, 0, 24, 20)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -2510,7 +2573,10 @@ func TestUpdate(t *testing.T) {
 					cvs,
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
-					&terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				testcanvas.MustApply(cvs, ft)
 				return ft
@@ -2542,7 +2608,10 @@ func TestUpdate(t *testing.T) {
 					cvs,
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
-					&terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonRelease},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonRelease},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				testcanvas.MustApply(cvs, ft)
 				return ft

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -1145,7 +1145,7 @@ func TestKeyboard(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1213,7 +1213,7 @@ func TestKeyboard(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1435,7 +1435,7 @@ func TestMouse(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{24, 9}, Button: mouse.ButtonRelease},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1523,7 +1523,7 @@ func TestMouse(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{22, 7}, Button: mouse.ButtonRelease},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1563,7 +1563,7 @@ func TestMouse(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				fakewidget.MustDraw(
@@ -1616,7 +1616,7 @@ func TestMouse(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1656,7 +1656,7 @@ func TestMouse(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				fakewidget.MustDraw(
@@ -1709,8 +1709,9 @@ func TestMouse(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					// Also gets the key, since we are sending two events above.
 					&fakewidget.Event{
-						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
-						Meta: &widgetapi.EventMeta{},
+						Ev: &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						// Also is focused at the time of the first event.
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				fakewidget.MustDraw(
@@ -1720,7 +1721,7 @@ func TestMouse(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1787,7 +1788,7 @@ func TestMouse(t *testing.T) {
 		},
 		{
 			desc:     "MouseScopeContainer, event forwarded if it falls on the container's border",
-			termSize: image.Point{21, 20},
+			termSize: image.Point{23, 20},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -1813,12 +1814,12 @@ func TestMouse(t *testing.T) {
 
 				fakewidget.MustDraw(
 					ft,
-					testcanvas.MustNew(image.Rect(1, 1, 20, 19)),
+					testcanvas.MustNew(image.Rect(1, 1, 22, 19)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1826,7 +1827,7 @@ func TestMouse(t *testing.T) {
 		},
 		{
 			desc:     "MouseScopeGlobal, event forwarded if it falls on the container's border",
-			termSize: image.Point{21, 20},
+			termSize: image.Point{23, 20},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -1852,12 +1853,12 @@ func TestMouse(t *testing.T) {
 
 				fakewidget.MustDraw(
 					ft,
-					testcanvas.MustNew(image.Rect(1, 1, 20, 19)),
+					testcanvas.MustNew(image.Rect(1, 1, 22, 19)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1896,7 +1897,7 @@ func TestMouse(t *testing.T) {
 		},
 		{
 			desc:     "MouseScopeContainer event forwarded if it falls outside of widget's canvas",
-			termSize: image.Point{20, 20},
+			termSize: image.Point{22, 20},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -1918,12 +1919,12 @@ func TestMouse(t *testing.T) {
 
 				fakewidget.MustDraw(
 					ft,
-					testcanvas.MustNew(image.Rect(0, 5, 20, 15)),
+					testcanvas.MustNew(image.Rect(0, 4, 22, 15)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -1931,7 +1932,7 @@ func TestMouse(t *testing.T) {
 		},
 		{
 			desc:     "MouseScopeGlobal event forwarded if it falls outside of widget's canvas",
-			termSize: image.Point{20, 20},
+			termSize: image.Point{22, 20},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -1953,12 +1954,12 @@ func TestMouse(t *testing.T) {
 
 				fakewidget.MustDraw(
 					ft,
-					testcanvas.MustNew(image.Rect(0, 5, 20, 15)),
+					testcanvas.MustNew(image.Rect(0, 4, 22, 15)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{-1, -1}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -2105,7 +2106,7 @@ func TestMouse(t *testing.T) {
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -2113,7 +2114,7 @@ func TestMouse(t *testing.T) {
 		},
 		{
 			desc:     "mouse position adjusted relative to widget's canvas, horizontal offset",
-			termSize: image.Point{30, 20},
+			termSize: image.Point{40, 30},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -2135,12 +2136,12 @@ func TestMouse(t *testing.T) {
 
 				fakewidget.MustDraw(
 					ft,
-					testcanvas.MustNew(image.Rect(6, 0, 24, 20)),
+					testcanvas.MustNew(image.Rect(6, 0, 33, 30)),
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -2544,7 +2545,7 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			desc:     "newly placed widget gets keyboard events",
-			termSize: image.Point{10, 10},
+			termSize: image.Point{12, 10},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -2575,7 +2576,7 @@ func TestUpdate(t *testing.T) {
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				testcanvas.MustApply(cvs, ft)
@@ -2584,7 +2585,7 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			desc:     "newly placed widget gets mouse events",
-			termSize: image.Point{20, 10},
+			termSize: image.Point{22, 10},
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -2610,7 +2611,7 @@ func TestUpdate(t *testing.T) {
 					widgetapi.Options{WantMouse: widgetapi.MouseScopeWidget},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonRelease},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				testcanvas.MustApply(cvs, ft)

--- a/private/fakewidget/fakewidget.go
+++ b/private/fakewidget/fakewidget.go
@@ -53,11 +53,15 @@ type Event struct {
 
 // Mirror is a fake widget. The fake widget draws a border around its assigned
 // canvas and writes the size of its assigned canvas on the first line of the
-// canvas. It writes the last received keyboard event onto the second line. It
-// writes the last received mouse event onto the third line. If a non-empty
-// string is provided via the Text() method, that text will be written right
-// after the canvas size on the first line. If the widget's container is
-// focused it writes "focus" onto the fourth line.
+// canvas.
+//
+// It writes the last received keyboard event onto the second line. It
+// writes the last received mouse event onto the third line. If the widget was
+// focused at the time of the event, the event will be prepended with a "F:".
+//
+// If a non-empty string is provided via the Text() method, that text will be
+// written right after the canvas size on the first line. If the widget's
+// container is focused it writes "focus" onto the fourth line.
 //
 // The widget requests the same options that are provided to the constructor.
 // If the options or canvas size don't allow for the lines mentioned above, the
@@ -142,7 +146,11 @@ func (mi *Mirror) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) e
 		mi.lines[keyboardLine] = ""
 		return fmt.Errorf("fakewidget received keyboard event: %v", k)
 	}
-	mi.lines[keyboardLine] = k.Key.String()
+	if meta.Focused {
+		mi.lines[keyboardLine] = fmt.Sprintf("F:%s", k.Key.String())
+	} else {
+		mi.lines[keyboardLine] = k.Key.String()
+	}
 	return nil
 }
 
@@ -159,7 +167,11 @@ func (mi *Mirror) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 		mi.lines[mouseLine] = ""
 		return fmt.Errorf("fakewidget received mouse event: %v", m)
 	}
-	mi.lines[mouseLine] = fmt.Sprintf("%v%v", m.Position, m.Button)
+	if meta.Focused {
+		mi.lines[mouseLine] = fmt.Sprintf("F:%v%v", m.Position, m.Button)
+	} else {
+		mi.lines[mouseLine] = fmt.Sprintf("%v%v", m.Position, m.Button)
+	}
 	return nil
 }
 

--- a/private/fakewidget/fakewidget_test.go
+++ b/private/fakewidget/fakewidget_test.go
@@ -276,14 +276,14 @@ func TestMirror(t *testing.T) {
 			}
 
 			for _, keyEv := range tc.keyEvents {
-				err := w.Keyboard(keyEv.k)
+				err := w.Keyboard(keyEv.k, &widgetapi.EventMeta{})
 				if (err != nil) != keyEv.wantErr {
 					t.Errorf("Keyboard => got error:%v, wantErr: %v", err, keyEv.wantErr)
 				}
 			}
 
 			for _, mouseEv := range tc.mouseEvents {
-				err := w.Mouse(mouseEv.m)
+				err := w.Mouse(mouseEv.m, &widgetapi.EventMeta{})
 				if (err != nil) != mouseEv.wantErr {
 					t.Errorf("Mouse => got error:%v, wantErr: %v", err, mouseEv.wantErr)
 				}
@@ -325,7 +325,7 @@ func TestDraw(t *testing.T) {
 		opts    widgetapi.Options
 		cvs     *canvas.Canvas
 		meta    *widgetapi.Meta
-		events  []terminalapi.Event
+		events  []*Event
 		want    func(size image.Point) *faketerm.Terminal
 		wantErr bool
 	}{
@@ -359,9 +359,15 @@ func TestDraw(t *testing.T) {
 			},
 			cvs:  testcanvas.MustNew(image.Rect(0, 0, 17, 5)),
 			meta: &widgetapi.Meta{},
-			events: []terminalapi.Event{
-				&terminalapi.Keyboard{Key: keyboard.KeyEnter},
-				&terminalapi.Mouse{Button: mouse.ButtonLeft},
+			events: []*Event{
+				{
+					Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					Meta: &widgetapi.EventMeta{},
+				},
+				{
+					Ev:   &terminalapi.Mouse{Button: mouse.ButtonLeft},
+					Meta: &widgetapi.EventMeta{},
+				},
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)

--- a/termdash_test.go
+++ b/termdash_test.go
@@ -253,7 +253,10 @@ func TestRun(t *testing.T) {
 					widgetapi.Options{
 						WantMouse: widgetapi.MouseScopeWidget,
 					},
-					&terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -281,7 +284,10 @@ func TestRun(t *testing.T) {
 						WantKeyboard: widgetapi.KeyScopeFocused,
 						WantMouse:    widgetapi.MouseScopeWidget,
 					},
-					&terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -347,7 +353,10 @@ func TestRun(t *testing.T) {
 					widgetapi.Options{
 						WantKeyboard: widgetapi.KeyScopeFocused,
 					},
-					&terminalapi.Keyboard{Key: keyboard.KeyF1},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyF1},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -382,7 +391,10 @@ func TestRun(t *testing.T) {
 					widgetapi.Options{
 						WantMouse: widgetapi.MouseScopeWidget,
 					},
-					&terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonWheelUp},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonWheelUp},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 			},
@@ -491,7 +503,10 @@ func TestController(t *testing.T) {
 						WantKeyboard: widgetapi.KeyScopeFocused,
 						WantMouse:    widgetapi.MouseScopeWidget,
 					},
-					&terminalapi.Keyboard{Key: keyboard.KeyEnter},
+					&fakewidget.Event{
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
+						Meta: &widgetapi.EventMeta{},
+					},
 				)
 				return ft
 

--- a/termdash_test.go
+++ b/termdash_test.go
@@ -255,7 +255,7 @@ func TestRun(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonLeft},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -286,7 +286,7 @@ func TestRun(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -355,7 +355,7 @@ func TestRun(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyF1},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -393,7 +393,7 @@ func TestRun(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Mouse{Position: image.Point{0, 0}, Button: mouse.ButtonWheelUp},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft
@@ -505,7 +505,7 @@ func TestController(t *testing.T) {
 					},
 					&fakewidget.Event{
 						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyEnter},
-						Meta: &widgetapi.EventMeta{},
+						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)
 				return ft

--- a/widgetapi/widgetapi.go
+++ b/widgetapi/widgetapi.go
@@ -145,6 +145,14 @@ type Meta struct {
 	Focused bool
 }
 
+// EventMeta provides additional metadata about events to widgets.
+type EventMeta struct {
+	// Focused asserts whether the widget's container is focused at the time of the event.
+	// If the event itself changes focus, the value here reflects the state of
+	// the focus after the change.
+	Focused bool
+}
+
 // Widget is a single widget on the dashboard.
 // Implementations must be thread safe.
 type Widget interface {
@@ -159,15 +167,17 @@ type Widget interface {
 	// The argument meta is guaranteed to be valid (i.e. non-nil).
 	Draw(cvs *canvas.Canvas, meta *Meta) error
 
-	// Keyboard is called when the widget is focused on the dashboard and a key
-	// shortcut the widget registered for was pressed. Only called if the widget
-	// registered for keyboard events.
-	Keyboard(k *terminalapi.Keyboard) error
+	// Keyboard is called with every keyboard event whose scope the widget
+	// registered for.
+	//
+	// The argument meta is guaranteed to be valid (i.e. non-nil).
+	Keyboard(k *terminalapi.Keyboard, meta *EventMeta) error
 
-	// Mouse is called when the widget is focused on the dashboard and a mouse
-	// event happens on its canvas. Only called if the widget registered for mouse
-	// events.
-	Mouse(m *terminalapi.Mouse) error
+	// Mouse is called with every mouse event whose scope the widget registered
+	// for.
+	//
+	// The argument meta is guaranteed to be valid (i.e. non-nil).
+	Mouse(m *terminalapi.Mouse, meta *EventMeta) error
 
 	// Options returns registration options for the widget.
 	// This is how the widget indicates to the infrastructure whether it is

--- a/widgets/barchart/barchart.go
+++ b/widgets/barchart/barchart.go
@@ -280,12 +280,12 @@ func (bc *BarChart) Values(values []int, max int, opts ...Option) error {
 }
 
 // Keyboard input isn't supported on the BarChart widget.
-func (*BarChart) Keyboard(k *terminalapi.Keyboard) error {
+func (*BarChart) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the BarChart widget doesn't support keyboard events")
 }
 
 // Mouse input isn't supported on the BarChart widget.
-func (*BarChart) Mouse(m *terminalapi.Mouse) error {
+func (*BarChart) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	return errors.New("the BarChart widget doesn't support mouse events")
 }
 

--- a/widgets/button/button.go
+++ b/widgets/button/button.go
@@ -172,7 +172,7 @@ func (b *Button) keyActivated(k *terminalapi.Keyboard) bool {
 // Key.
 //
 // Implements widgetapi.Widget.Keyboard.
-func (b *Button) Keyboard(k *terminalapi.Keyboard) error {
+func (b *Button) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	if b.keyActivated(k) {
 		// Mutex must be released when calling the callback.
 		// Users might call container methods from the callback like the
@@ -198,7 +198,7 @@ func (b *Button) mouseActivated(m *terminalapi.Mouse) bool {
 // the release happen inside the button.
 //
 // Implements widgetapi.Widget.Mouse.
-func (b *Button) Mouse(m *terminalapi.Mouse) error {
+func (b *Button) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	if b.mouseActivated(m) {
 		// Mutex must be released when calling the callback.
 		// Users might call container methods from the callback like the

--- a/widgets/button/button_test.go
+++ b/widgets/button/button_test.go
@@ -648,7 +648,7 @@ func TestButton(t *testing.T) {
 			for i, ev := range tc.events {
 				switch e := ev.(type) {
 				case *terminalapi.Mouse:
-					err := b.Mouse(e)
+					err := b.Mouse(e, &widgetapi.EventMeta{})
 					// Only the last event in test cases is the one that triggers the callback.
 					if i == len(tc.events)-1 {
 						if (err != nil) != tc.wantCallbackErr {
@@ -664,7 +664,7 @@ func TestButton(t *testing.T) {
 					}
 
 				case *terminalapi.Keyboard:
-					err := b.Keyboard(e)
+					err := b.Keyboard(e, &widgetapi.EventMeta{})
 					// Only the last event in test cases is the one that triggers the callback.
 					if i == len(tc.events)-1 {
 						if (err != nil) != tc.wantCallbackErr {

--- a/widgets/donut/donut.go
+++ b/widgets/donut/donut.go
@@ -273,12 +273,12 @@ func (d *Donut) Draw(cvs *canvas.Canvas, meta *widgetapi.Meta) error {
 }
 
 // Keyboard input isn't supported on the Donut widget.
-func (*Donut) Keyboard(k *terminalapi.Keyboard) error {
+func (*Donut) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the Donut widget doesn't support keyboard events")
 }
 
 // Mouse input isn't supported on the Donut widget.
-func (*Donut) Mouse(m *terminalapi.Mouse) error {
+func (*Donut) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	return errors.New("the Donut widget doesn't support mouse events")
 }
 

--- a/widgets/donut/donut_test.go
+++ b/widgets/donut/donut_test.go
@@ -883,7 +883,7 @@ func TestKeyboard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := d.Keyboard(&terminalapi.Keyboard{}); err == nil {
+	if err := d.Keyboard(&terminalapi.Keyboard{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Keyboard => got nil err, wanted one")
 	}
 }
@@ -893,7 +893,7 @@ func TestMouse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := d.Mouse(&terminalapi.Mouse{}); err == nil {
+	if err := d.Mouse(&terminalapi.Mouse{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Mouse => got nil err, wanted one")
 	}
 }

--- a/widgets/gauge/gauge.go
+++ b/widgets/gauge/gauge.go
@@ -288,12 +288,12 @@ func (g *Gauge) Draw(cvs *canvas.Canvas, meta *widgetapi.Meta) error {
 }
 
 // Keyboard input isn't supported on the Gauge widget.
-func (g *Gauge) Keyboard(k *terminalapi.Keyboard) error {
+func (g *Gauge) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the Gauge widget doesn't support keyboard events")
 }
 
 // Mouse input isn't supported on the Gauge widget.
-func (g *Gauge) Mouse(m *terminalapi.Mouse) error {
+func (g *Gauge) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	return errors.New("the Gauge widget doesn't support mouse events")
 }
 

--- a/widgets/gauge/gauge_test.go
+++ b/widgets/gauge/gauge_test.go
@@ -908,7 +908,7 @@ func TestKeyboard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := g.Keyboard(&terminalapi.Keyboard{}); err == nil {
+	if err := g.Keyboard(&terminalapi.Keyboard{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Keyboard => got nil err, wanted one")
 	}
 }
@@ -918,7 +918,7 @@ func TestMouse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := g.Mouse(&terminalapi.Mouse{}); err == nil {
+	if err := g.Mouse(&terminalapi.Mouse{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Mouse => got nil err, wanted one")
 	}
 }

--- a/widgets/heatmap/heatmap.go
+++ b/widgets/heatmap/heatmap.go
@@ -128,12 +128,12 @@ func (hp *HeatMap) minSize() image.Point {
 }
 
 // Keyboard input isn't supported on the HeatMap widget.
-func (*HeatMap) Keyboard(k *terminalapi.Keyboard) error {
+func (*HeatMap) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the HeatMap widget doesn't support keyboard events")
 }
 
 // Mouse input isn't supported on the HeatMap widget.
-func (*HeatMap) Mouse(m *terminalapi.Mouse) error {
+func (*HeatMap) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	return errors.New("the HeatMap widget doesn't support mouse events")
 }
 

--- a/widgets/linechart/linechart.go
+++ b/widgets/linechart/linechart.go
@@ -478,12 +478,12 @@ func (lc *LineChart) highlightRange(bc *braille.Canvas, hRange *zoom.Range) erro
 }
 
 // Keyboard implements widgetapi.Widget.Keyboard.
-func (lc *LineChart) Keyboard(k *terminalapi.Keyboard) error {
+func (lc *LineChart) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the LineChart widget doesn't support keyboard events")
 }
 
 // Mouse implements widgetapi.Widget.Mouse.
-func (lc *LineChart) Mouse(m *terminalapi.Mouse) error {
+func (lc *LineChart) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 

--- a/widgets/linechart/linechart_test.go
+++ b/widgets/linechart/linechart_test.go
@@ -1171,7 +1171,7 @@ func TestLineChartDraws(t *testing.T) {
 				return lc.Mouse(&terminalapi.Mouse{
 					Position: image.Point{6, 5},
 					Button:   mouse.ButtonLeft,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			wantCapacity: 28,
 			want: func(size image.Point) *faketerm.Terminal {
@@ -1222,7 +1222,7 @@ func TestLineChartDraws(t *testing.T) {
 				return lc.Mouse(&terminalapi.Mouse{
 					Position: image.Point{6, 5},
 					Button:   mouse.ButtonLeft,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			wantCapacity: 28,
 			want: func(size image.Point) *faketerm.Terminal {
@@ -1273,7 +1273,7 @@ func TestLineChartDraws(t *testing.T) {
 				return lc.Mouse(&terminalapi.Mouse{
 					Position: image.Point{8, 5},
 					Button:   mouse.ButtonWheelUp,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			wantCapacity: 28,
 			want: func(size image.Point) *faketerm.Terminal {
@@ -1331,7 +1331,7 @@ func TestLineChartDraws(t *testing.T) {
 				return lc.Mouse(&terminalapi.Mouse{
 					Position: image.Point{6, 7},
 					Button:   mouse.ButtonLeft,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			wantCapacity: 28,
 			want: func(size image.Point) *faketerm.Terminal {
@@ -1388,7 +1388,7 @@ func TestLineChartDraws(t *testing.T) {
 				return lc.Mouse(&terminalapi.Mouse{
 					Position: image.Point{5, 0},
 					Button:   mouse.ButtonWheelUp,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			wantCapacity: 10,
 			want: func(size image.Point) *faketerm.Terminal {
@@ -1443,7 +1443,7 @@ func TestLineChartDraws(t *testing.T) {
 				if err := lc.Mouse(&terminalapi.Mouse{
 					Position: image.Point{5, 0},
 					Button:   mouse.ButtonWheelUp,
-				}); err != nil {
+				}, &widgetapi.EventMeta{}); err != nil {
 					return err
 				}
 
@@ -1901,7 +1901,7 @@ func TestKeyboard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := lc.Keyboard(&terminalapi.Keyboard{}); err == nil {
+	if err := lc.Keyboard(&terminalapi.Keyboard{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Keyboard => got nil err, wanted one")
 	}
 }
@@ -1911,7 +1911,7 @@ func TestMouseDoesNothingWithoutZoomTracker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := lc.Mouse(&terminalapi.Mouse{}); err != nil {
+	if err := lc.Mouse(&terminalapi.Mouse{}, &widgetapi.EventMeta{}); err != nil {
 		t.Errorf("Mouse => unexpected error: %v", err)
 	}
 }

--- a/widgets/segmentdisplay/segmentdisplay.go
+++ b/widgets/segmentdisplay/segmentdisplay.go
@@ -292,12 +292,12 @@ func (sd *SegmentDisplay) drawChar(dCvs *canvas.Canvas, c rune, wOpts *writeOpti
 }
 
 // Keyboard input isn't supported on the SegmentDisplay widget.
-func (*SegmentDisplay) Keyboard(k *terminalapi.Keyboard) error {
+func (*SegmentDisplay) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the SegmentDisplay widget doesn't support keyboard events")
 }
 
 // Mouse input isn't supported on the SegmentDisplay widget.
-func (*SegmentDisplay) Mouse(m *terminalapi.Mouse) error {
+func (*SegmentDisplay) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	return errors.New("the SegmentDisplay widget doesn't support mouse events")
 }
 

--- a/widgets/segmentdisplay/segmentdisplay_test.go
+++ b/widgets/segmentdisplay/segmentdisplay_test.go
@@ -982,7 +982,7 @@ func TestKeyboard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := sd.Keyboard(&terminalapi.Keyboard{}); err == nil {
+	if err := sd.Keyboard(&terminalapi.Keyboard{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Keyboard => got nil err, wanted one")
 	}
 }
@@ -992,7 +992,7 @@ func TestMouse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New => unexpected error: %v", err)
 	}
-	if err := sd.Mouse(&terminalapi.Mouse{}); err == nil {
+	if err := sd.Mouse(&terminalapi.Mouse{}, &widgetapi.EventMeta{}); err == nil {
 		t.Errorf("Mouse => got nil err, wanted one")
 	}
 }

--- a/widgets/sparkline/sparkline.go
+++ b/widgets/sparkline/sparkline.go
@@ -183,12 +183,12 @@ func (sl *SparkLine) Clear() {
 }
 
 // Keyboard input isn't supported on the SparkLine widget.
-func (*SparkLine) Keyboard(k *terminalapi.Keyboard) error {
+func (*SparkLine) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	return errors.New("the SparkLine widget doesn't support keyboard events")
 }
 
 // Mouse input isn't supported on the SparkLine widget.
-func (*SparkLine) Mouse(m *terminalapi.Mouse) error {
+func (*SparkLine) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	return errors.New("the SparkLine widget doesn't support mouse events")
 }
 

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -234,7 +234,7 @@ func (t *Text) Draw(cvs *canvas.Canvas, meta *widgetapi.Meta) error {
 }
 
 // Keyboard implements widgetapi.Widget.Keyboard.
-func (t *Text) Keyboard(k *terminalapi.Keyboard) error {
+func (t *Text) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -252,7 +252,7 @@ func (t *Text) Keyboard(k *terminalapi.Keyboard) error {
 }
 
 // Mouse implements widgetapi.Widget.Mouse.
-func (t *Text) Mouse(m *terminalapi.Mouse) error {
+func (t *Text) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -310,7 +310,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Mouse(&terminalapi.Mouse{
 					Button: mouse.ButtonWheelDown,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -332,7 +332,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Mouse(&terminalapi.Mouse{
 					Button: mouse.ButtonWheelDown,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -353,7 +353,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: keyboard.KeyArrowDown,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -375,7 +375,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: keyboard.KeyPgDn,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -400,7 +400,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Mouse(&terminalapi.Mouse{
 					Button: mouse.ButtonRight,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -425,7 +425,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: 'd',
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -450,7 +450,7 @@ func TestTextDraws(t *testing.T) {
 			events: func(widget *Text) {
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: 'l',
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -648,7 +648,7 @@ func TestTextDraws(t *testing.T) {
 				}
 				widget.Mouse(&terminalapi.Mouse{
 					Button: mouse.ButtonWheelUp,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -677,7 +677,7 @@ func TestTextDraws(t *testing.T) {
 				}
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: keyboard.KeyArrowUp,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -706,7 +706,7 @@ func TestTextDraws(t *testing.T) {
 				}
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: keyboard.KeyPgUp,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -736,7 +736,7 @@ func TestTextDraws(t *testing.T) {
 				}
 				widget.Mouse(&terminalapi.Mouse{
 					Button: mouse.ButtonLeft,
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -766,7 +766,7 @@ func TestTextDraws(t *testing.T) {
 				}
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: 'u',
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -796,7 +796,7 @@ func TestTextDraws(t *testing.T) {
 				}
 				widget.Keyboard(&terminalapi.Keyboard{
 					Key: 'k',
-				})
+				}, &widgetapi.EventMeta{})
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)

--- a/widgets/textinput/textinput.go
+++ b/widgets/textinput/textinput.go
@@ -267,7 +267,7 @@ func (ti *TextInput) keyboard(k *terminalapi.Keyboard) (bool, string) {
 
 // Keyboard processes keyboard events.
 // Implements widgetapi.Widget.Keyboard.
-func (ti *TextInput) Keyboard(k *terminalapi.Keyboard) error {
+func (ti *TextInput) Keyboard(k *terminalapi.Keyboard, meta *widgetapi.EventMeta) error {
 	if submitted, text := ti.keyboard(k); submitted {
 		// Mutex must be released when calling the callback.
 		// Users might call container methods from the callback like the
@@ -279,7 +279,7 @@ func (ti *TextInput) Keyboard(k *terminalapi.Keyboard) error {
 
 // Mouse processes mouse events.
 // Implements widgetapi.Widget.Mouse.
-func (ti *TextInput) Mouse(m *terminalapi.Mouse) error {
+func (ti *TextInput) Mouse(m *terminalapi.Mouse, meta *widgetapi.EventMeta) error {
 	ti.mu.Lock()
 	defer ti.mu.Unlock()
 

--- a/widgets/textinput/textinput_test.go
+++ b/widgets/textinput/textinput_test.go
@@ -1441,7 +1441,7 @@ func TestTextInput(t *testing.T) {
 			for i, ev := range tc.events {
 				switch e := ev.(type) {
 				case *terminalapi.Mouse:
-					err := ti.Mouse(e)
+					err := ti.Mouse(e, &widgetapi.EventMeta{})
 					// Only the last event in test cases is the one that triggers the callback.
 					if i == len(tc.events)-1 {
 						if (err != nil) != tc.wantEventErr {
@@ -1457,7 +1457,7 @@ func TestTextInput(t *testing.T) {
 					}
 
 				case *terminalapi.Keyboard:
-					err := ti.Keyboard(e)
+					err := ti.Keyboard(e, &widgetapi.EventMeta{})
 					// Only the last event in test cases is the one that triggers the callback.
 					if i == len(tc.events)-1 {
 						if (err != nil) != tc.wantEventErr {
@@ -1551,7 +1551,7 @@ func TestTextInputRead(t *testing.T) {
 			for _, ev := range tc.events {
 				switch e := ev.(type) {
 				case *terminalapi.Keyboard:
-					err := ti.Keyboard(e)
+					err := ti.Keyboard(e, &widgetapi.EventMeta{})
 					if err != nil {
 						t.Fatalf("Keyboard => unexpected error: %v", err)
 					}


### PR DESCRIPTION
Initially lets the widget know if it container was focused at the time of the event.

Works on #243.