### PR TITLE
Support closed focus groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `widgetapi.Widget.Keyboard` and `widgetapi.Widget.Mouse` methods now
   accepts a second argument which provides widgets with additional metadata.
   All widgets implemented outside of the `termdash` repository will need to be
-  similarly to the `Barchart` example below. Change the original method
+  updated similarly to the `Barchart` example below. Change the original method
   signatures:
   ```go
   func (*BarChart) Keyboard(k *terminalapi.Keyboard) error { ... }
@@ -32,16 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Infrastructure changes
 
-- ability to configure keyboard keys that move focus to the next or the
-  previous container.
+- `container` now allows users to configure keyboard keys that move focus to
+  the next or the previous container.
 - containers can request to be skipped when focus is moved using keyboard keys.
 - containers can register into separate focus groups and specific keyboard keys
   can be configured to move the focus within each focus group.
 - widgets can now request keyboard events exclusively when focused.
-- ability to configure keyboard keys that move focus to the next or the
-  previous container.
-- `container` now allows users to configure keyboard keys that move focus to
-  the next or the previous container.
 
 #### Updates to the `button` widget
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ability to configure keyboard keys that move focus to the next or the
   previous container.
 - containers can request to be skipped when focus is moved using keyboard keys.
+- containers can register into separate focus groups and specific keyboard keys
+  can be configured to move the focus within each focus group.
 - widgets can now request keyboard events exclusively when focused.
 - ability to configure keyboard keys that move focus to the next or the
   previous container.

--- a/container/container.go
+++ b/container/container.go
@@ -289,16 +289,17 @@ func (c *Container) inFocusGroup(fg FocusGroup) bool {
 // changes the focused container.
 // Caller must hold c.mu.
 func (c *Container) updateFocusFromKeyboard(k *terminalapi.Keyboard) {
-	nextGroupsForKey, isGroupKeyForNext := c.opts.global.keyFocusGroupsNext[k.Key]
-	prevGroupsForKey, isGroupKeyForPrev := c.opts.global.keyFocusGroupsPrevious[k.Key]
+	active := c.focusTracker.active()
+	nextGroupsForKey, isGroupKeyForNext := active.opts.global.keyFocusGroupsNext[k.Key]
+	prevGroupsForKey, isGroupKeyForPrev := active.opts.global.keyFocusGroupsPrevious[k.Key]
 
-	nextMatchesContGroup, nextG := nextGroupsForKey.firstMatching(c.opts.keyFocusGroups)
-	prevMatchesContGroup, prevG := prevGroupsForKey.firstMatching(c.opts.keyFocusGroups)
+	nextMatchesContGroup, nextG := nextGroupsForKey.firstMatching(active.opts.keyFocusGroups)
+	prevMatchesContGroup, prevG := prevGroupsForKey.firstMatching(active.opts.keyFocusGroups)
 
 	switch {
-	case c.opts.global.keyFocusNext != nil && *c.opts.global.keyFocusNext == k.Key:
+	case active.opts.global.keyFocusNext != nil && *active.opts.global.keyFocusNext == k.Key:
 		c.focusTracker.next( /* group = */ nil)
-	case c.opts.global.keyFocusPrevious != nil && *c.opts.global.keyFocusPrevious == k.Key:
+	case active.opts.global.keyFocusPrevious != nil && *active.opts.global.keyFocusPrevious == k.Key:
 		c.focusTracker.previous( /* group = */ nil)
 	case isGroupKeyForNext && nextMatchesContGroup:
 		c.focusTracker.next(&nextG)

--- a/container/container.go
+++ b/container/container.go
@@ -279,11 +279,18 @@ func (c *Container) updateFocusFromMouse(m *terminalapi.Mouse) {
 // changes the focused container.
 // Caller must hold c.mu.
 func (c *Container) updateFocusFromKeyboard(k *terminalapi.Keyboard) {
+	inNextFg, isGroupKeyForNext := c.opts.global.keysFocusGroupsNext[k.Key]
+	inPrevFg, isGroupKeyForPrev := c.opts.global.keysFocusGroupsPrevious[k.Key]
+
 	switch {
 	case c.opts.global.keyFocusNext != nil && *c.opts.global.keyFocusNext == k.Key:
-		c.focusTracker.next()
+		c.focusTracker.next( /* group = */ nil)
 	case c.opts.global.keyFocusPrevious != nil && *c.opts.global.keyFocusPrevious == k.Key:
-		c.focusTracker.previous()
+		c.focusTracker.previous( /* group = */ nil)
+	case isGroupKeyForNext && inNextFg[c.opts.keyFocusGroup]:
+		c.focusTracker.next(&c.opts.keyFocusGroup)
+	case isGroupKeyForPrev && inPrevFg[c.opts.keyFocusGroup]:
+		c.focusTracker.previous(&c.opts.keyFocusGroup)
 	}
 }
 

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -530,6 +530,63 @@ func TestNew(t *testing.T) {
 			wantContainerErr: true,
 		},
 		{
+			desc:     "fails on KeyFocusGroups with a negative group",
+			termSize: image.Point{10, 20},
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusGroups(0, -1),
+				)
+			},
+			wantContainerErr: true,
+		},
+		{
+			desc:     "fails on KeyFocusGroupsNext with a negative group",
+			termSize: image.Point{10, 20},
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusGroupsNext('n', 0, -1),
+				)
+			},
+			wantContainerErr: true,
+		},
+		{
+			desc:     "fails on KeyFocusGroupsPrevious with a negative group",
+			termSize: image.Point{10, 20},
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusGroupsPrevious('p', 0, -1),
+				)
+			},
+			wantContainerErr: true,
+		},
+		{
+			desc:     "fails on KeyFocusGroupsNext with a key already assigned as KeyFocusGroupsPrevious",
+			termSize: image.Point{10, 20},
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusGroupsPrevious('n', 0),
+					KeyFocusGroupsNext('n', 0),
+				)
+			},
+			wantContainerErr: true,
+		},
+		{
+			desc:     "fails on KeyFocusGroupsPrevious with a key already assigned as KeyFocusGroupsNext",
+			termSize: image.Point{10, 20},
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusGroupsNext('n', 0),
+					KeyFocusGroupsPrevious('n', 0),
+				)
+			},
+			wantContainerErr: true,
+		},
+		{
 			desc:     "empty container",
 			termSize: image.Point{10, 10},
 			container: func(ft *faketerm.Terminal) (*Container, error) {

--- a/container/focus.go
+++ b/container/focus.go
@@ -68,6 +68,11 @@ func newFocusTracker(c *Container) *focusTracker {
 	}
 }
 
+// active returns container that is currently active.
+func (ft *focusTracker) active() *Container {
+	return ft.container
+}
+
 // isActive determines if the provided container is the currently active container.
 func (ft *focusTracker) isActive(c *Container) bool {
 	return ft.container == c

--- a/container/focus.go
+++ b/container/focus.go
@@ -79,7 +79,9 @@ func (ft *focusTracker) setActive(c *Container) {
 }
 
 // next moves focus to the next container.
-func (ft *focusTracker) next() {
+// If group is not nil, focus will only move between containers with a matching
+// focus group number.
+func (ft *focusTracker) next(group *int) {
 	var (
 		errStr    string
 		firstCont *Container
@@ -92,10 +94,15 @@ func (ft *focusTracker) next() {
 			return nil
 		}
 
-		if c.isLeaf() && !c.opts.keyFocusSkip && firstCont == nil {
+		if firstCont == nil && c.isLeaf() {
 			// Remember the first eligible container in case we "wrap" over,
 			// i.e. finish the iteration before finding the next container.
-			firstCont = c
+			switch {
+			case group == nil && !c.opts.keyFocusSkip:
+				fallthrough
+			case group != nil && c.opts.keyFocusGroup == *group:
+				firstCont = c
+			}
 		}
 
 		if ft.container == c {
@@ -105,8 +112,13 @@ func (ft *focusTracker) next() {
 			return nil
 		}
 
-		if c.isLeaf() && !c.opts.keyFocusSkip && focusNext {
-			nextCont = c
+		if focusNext && c.isLeaf() {
+			switch {
+			case group == nil && !c.opts.keyFocusSkip:
+				fallthrough
+			case group != nil && c.opts.keyFocusGroup == *group:
+				nextCont = c
+			}
 		}
 		return nil
 	}))
@@ -121,7 +133,9 @@ func (ft *focusTracker) next() {
 }
 
 // previous moves focus to the previous container.
-func (ft *focusTracker) previous() {
+// If group is not nil, focus will only move between containers with a matching
+// focus group number.
+func (ft *focusTracker) previous(group *int) {
 	var (
 		errStr      string
 		prevCont    *Container
@@ -133,13 +147,18 @@ func (ft *focusTracker) previous() {
 			visitedCurr = true
 		}
 
-		if c.isLeaf() && !c.opts.keyFocusSkip {
-			if !visitedCurr {
-				// Remember the last eligible container closest to the one
-				// currently focused.
-				prevCont = c
+		if c.isLeaf() {
+			switch {
+			case group == nil && !c.opts.keyFocusSkip:
+				fallthrough
+			case group != nil && c.opts.keyFocusGroup == *group:
+				if !visitedCurr {
+					// Remember the last eligible container closest to the one
+					// currently focused.
+					prevCont = c
+				}
+				lastCont = c
 			}
-			lastCont = c
 		}
 		return nil
 	}))

--- a/container/focus.go
+++ b/container/focus.go
@@ -81,7 +81,7 @@ func (ft *focusTracker) setActive(c *Container) {
 // next moves focus to the next container.
 // If group is not nil, focus will only move between containers with a matching
 // focus group number.
-func (ft *focusTracker) next(group *int) {
+func (ft *focusTracker) next(group *FocusGroup) {
 	var (
 		errStr    string
 		firstCont *Container
@@ -100,7 +100,7 @@ func (ft *focusTracker) next(group *int) {
 			switch {
 			case group == nil && !c.opts.keyFocusSkip:
 				fallthrough
-			case group != nil && c.opts.keyFocusGroup == *group:
+			case group != nil && c.inFocusGroup(*group):
 				firstCont = c
 			}
 		}
@@ -116,7 +116,7 @@ func (ft *focusTracker) next(group *int) {
 			switch {
 			case group == nil && !c.opts.keyFocusSkip:
 				fallthrough
-			case group != nil && c.opts.keyFocusGroup == *group:
+			case group != nil && c.inFocusGroup(*group):
 				nextCont = c
 			}
 		}
@@ -135,7 +135,7 @@ func (ft *focusTracker) next(group *int) {
 // previous moves focus to the previous container.
 // If group is not nil, focus will only move between containers with a matching
 // focus group number.
-func (ft *focusTracker) previous(group *int) {
+func (ft *focusTracker) previous(group *FocusGroup) {
 	var (
 		errStr      string
 		prevCont    *Container
@@ -151,7 +151,7 @@ func (ft *focusTracker) previous(group *int) {
 			switch {
 			case group == nil && !c.opts.keyFocusSkip:
 				fallthrough
-			case group != nil && c.opts.keyFocusGroup == *group:
+			case group != nil && c.inFocusGroup(*group):
 				if !visitedCurr {
 					// Remember the last eligible container closest to the one
 					// currently focused.

--- a/container/focus_test.go
+++ b/container/focus_test.go
@@ -885,7 +885,7 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantProcessed: 1,
 		},
 		{
-			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupNext once focuses the first container",
+			desc: "containers don't belong to focus group by default",
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
@@ -893,7 +893,30 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 						Left(),
 						Right(),
 					),
-					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+					KeyFocusGroupsNext('n', 0),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'n'},
+			},
+			wantFocused:   contLocA,
+			wantProcessed: 1,
+		},
+		{
+			desc: "moves to the next container in focus group, pressing KeysFocusGroupNext once focuses the first container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					KeyFocusGroups(1),
+					SplitVertical(
+						Left(
+							KeyFocusGroups(1),
+						),
+						Right(
+							KeyFocusGroups(1),
+						),
+					),
+					KeyFocusGroupsNext('n', 1),
 				)
 			},
 			events: []*terminalapi.Keyboard{
@@ -903,15 +926,20 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantProcessed: 1,
 		},
 		{
-			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupNext twice focuses the second container",
+			desc: "moves to the next container in focus group, pressing KeysFocusGroupNext twice focuses the second container",
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
+					KeyFocusGroups(1),
 					SplitVertical(
-						Left(),
-						Right(),
+						Left(
+							KeyFocusGroups(1),
+						),
+						Right(
+							KeyFocusGroups(1),
+						),
 					),
-					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+					KeyFocusGroupsNext('n', 1),
 				)
 			},
 			events: []*terminalapi.Keyboard{
@@ -922,15 +950,20 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantProcessed: 2,
 		},
 		{
-			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupNext three times focuses the first container again",
+			desc: "moves to the next container in focus group, pressing KeysFocusGroupNext three times focuses the first container again",
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
+					KeyFocusGroups(2),
 					SplitVertical(
-						Left(),
-						Right(),
+						Left(
+							KeyFocusGroups(2),
+						),
+						Right(
+							KeyFocusGroups(2),
+						),
 					),
-					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+					KeyFocusGroupsNext('n', 2),
 				)
 			},
 			events: []*terminalapi.Keyboard{
@@ -942,15 +975,20 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantProcessed: 3,
 		},
 		{
-			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupPrevious once focuses the second container",
+			desc: "moves to the previous container in focus group, pressing KeysFocusGroupPrevious once focuses the second container",
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
+					KeyFocusGroups(1),
 					SplitVertical(
-						Left(),
-						Right(),
+						Left(
+							KeyFocusGroups(1),
+						),
+						Right(
+							KeyFocusGroups(1),
+						),
 					),
-					KeysFocusGroupPrevious(0, []keyboard.Key{'p'}),
+					KeyFocusGroupsPrevious('p', 1),
 				)
 			},
 			events: []*terminalapi.Keyboard{
@@ -960,15 +998,20 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantProcessed: 1,
 		},
 		{
-			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupPrevious twice focuses the first container",
+			desc: "moves to the previous container in focus group, pressing KeysFocusGroupPrevious twice focuses the first container",
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
+					KeyFocusGroups(1),
 					SplitVertical(
-						Left(),
-						Right(),
+						Left(
+							KeyFocusGroups(1),
+						),
+						Right(
+							KeyFocusGroups(1),
+						),
 					),
-					KeysFocusGroupPrevious(0, []keyboard.Key{'p'}),
+					KeyFocusGroupsPrevious('p', 1),
 				)
 			},
 			events: []*terminalapi.Keyboard{
@@ -979,15 +1022,20 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantProcessed: 2,
 		},
 		{
-			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupPrevious three times focuses the second container again",
+			desc: "moves to the previous container in focus group, pressing KeysFocusGroupPrevious three times focuses the second container again",
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
+					KeyFocusGroups(1),
 					SplitVertical(
-						Left(),
-						Right(),
+						Left(
+							KeyFocusGroups(1),
+						),
+						Right(
+							KeyFocusGroups(1),
+						),
 					),
-					KeysFocusGroupPrevious(0, []keyboard.Key{'p'}),
+					KeyFocusGroupsPrevious('p', 1),
 				)
 			},
 			events: []*terminalapi.Keyboard{
@@ -1003,15 +1051,18 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			container: func(ft *faketerm.Terminal) (*Container, error) {
 				return New(
 					ft,
+					KeyFocusGroups(1),
 					SplitVertical(
 						Left(
 							KeyFocusSkip(),
+							KeyFocusGroups(1),
 						),
 						Right(
 							KeyFocusSkip(),
+							KeyFocusGroups(1),
 						),
 					),
-					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+					KeyFocusGroupsNext('n', 1),
 				)
 			},
 			events: []*terminalapi.Keyboard{

--- a/container/focus_test.go
+++ b/container/focus_test.go
@@ -884,6 +884,120 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantFocused:   contLocA,
 			wantProcessed: 1,
 		},
+		{
+			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupNext once focuses the first container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'n'},
+			},
+			wantFocused:   contLocB,
+			wantProcessed: 1,
+		},
+		{
+			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupNext twice focuses the second container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'n'},
+				{Key: 'n'},
+			},
+			wantFocused:   contLocC,
+			wantProcessed: 2,
+		},
+		{
+			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupNext three times focuses the first container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'n'},
+				{Key: 'n'},
+				{Key: 'n'},
+			},
+			wantFocused:   contLocB,
+			wantProcessed: 3,
+		},
+		{
+			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupPrevious once focuses the second container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeysFocusGroupPrevious(0, []keyboard.Key{'p'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'p'},
+			},
+			wantFocused:   contLocC,
+			wantProcessed: 1,
+		},
+		{
+			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupPrevious twice focuses the first container",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeysFocusGroupPrevious(0, []keyboard.Key{'p'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'p'},
+				{Key: 'p'},
+			},
+			wantFocused:   contLocB,
+			wantProcessed: 2,
+		},
+		{
+			desc: "all containers are in focus group zero by default, pressing KeysFocusGroupPrevious three times focuses the second container again",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(),
+						Right(),
+					),
+					KeysFocusGroupPrevious(0, []keyboard.Key{'p'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'p'},
+				{Key: 'p'},
+				{Key: 'p'},
+			},
+			wantFocused:   contLocC,
+			wantProcessed: 3,
+		},
 	}
 
 	for _, tc := range tests {

--- a/container/focus_test.go
+++ b/container/focus_test.go
@@ -998,6 +998,28 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 			wantFocused:   contLocC,
 			wantProcessed: 3,
 		},
+		{
+			desc: "configuring container with KeyFocusSkip has no effect on a closed focus group",
+			container: func(ft *faketerm.Terminal) (*Container, error) {
+				return New(
+					ft,
+					SplitVertical(
+						Left(
+							KeyFocusSkip(),
+						),
+						Right(
+							KeyFocusSkip(),
+						),
+					),
+					KeysFocusGroupNext(0, []keyboard.Key{'n'}),
+				)
+			},
+			events: []*terminalapi.Keyboard{
+				{Key: 'n'},
+			},
+			wantFocused:   contLocB,
+			wantProcessed: 1,
+		},
 	}
 
 	for _, tc := range tests {

--- a/container/options.go
+++ b/container/options.go
@@ -940,7 +940,7 @@ func KeyFocusGroup(group int) Option {
 // This option is global and applies to all created containers.
 // Pressing either of (KeyFocusNext, KeyFocusPrevious) still moves the focus to
 // any container regardless of its focus group.
-func KeyFocusGroupNext(group int, keys []keyboard.Key) Option {
+func KeysFocusGroupNext(group int, keys []keyboard.Key) Option {
 	return option(func(c *Container) error {
 		if min := 0; group < min {
 			return fmt.Errorf("invalid group %d, must be 0 <= group", group)
@@ -978,7 +978,7 @@ func KeyFocusGroupNext(group int, keys []keyboard.Key) Option {
 // This option is global and applies to all created containers.
 // Pressing either of (KeyFocusNext, KeyFocusPrevious) still moves the focus to
 // any container regardless of its focus group.
-func KeyFocusGroupPrevious(group int, keys []keyboard.Key) Option {
+func KeysFocusGroupPrevious(group int, keys []keyboard.Key) Option {
 	return option(func(c *Container) error {
 		if min := 0; group < min {
 			return fmt.Errorf("invalid group %d, must be 0 <= group", group)

--- a/container/options.go
+++ b/container/options.go
@@ -924,7 +924,7 @@ func KeyFocusSkip() Option {
 // moved between them sharing the same keyboard key.
 type FocusGroup int
 
-// KeyFocusGroups assigns this container to focus groups of with the specified
+// KeyFocusGroups assigns this container to focus groups with the specified
 // numbers.
 //
 // See either of (KeysFocusGroupNext, KeysFocusGroupPrevious) for a description

--- a/container/options.go
+++ b/container/options.go
@@ -897,7 +897,8 @@ func KeyFocusPrevious(key keyboard.Key) Option {
 // focus when KeyFocusNext or KeyFocusPrevious is pressed.
 //
 // A container configured like this would still receive the keyboard focus when
-// directly clicked on with a mouse.
+// directly clicked on with a mouse or when via KeysFocusGroupNext or
+// KeysFocusGroupPrevious.
 func KeyFocusSkip() Option {
 	return option(func(c *Container) error {
 		c.opts.keyFocusSkip = true


### PR DESCRIPTION
Containers can register into separate focus groups and specific keyboard keys can be configured to move the focus within each focus group.

Works on #243 