### PR TITLE
Implements a buffer limit for the Text widget

### DIFF
--- a/widgets/text/options.go
+++ b/widgets/text/options.go
@@ -178,12 +178,14 @@ func ScrollKeys(up, down, pageUp, pageDown keyboard.Key) Option {
 }
 
 // The default for the maximum buffer length within a content area
-// -1 sets as no limit
+// -1 sets as no limit, for logs you may wish to try 10,000 or higher
 const (
 	DefaultMaxContent = -1
 )
 
-// MaxContent - Limits the maximum content within text widget buffer
+// MaxContent - Limits the maximum content within text widget buffer.
+// This is useful when sending large amounts of text to the Text widget, eg
+// when tailing logs as it will limit the memory usage.
 func MaxContent(max int) Option {
 	return option(func(opts *options) {
 		opts.maxContent = max

--- a/widgets/text/options.go
+++ b/widgets/text/options.go
@@ -36,6 +36,7 @@ type options struct {
 	scrollDown       rune
 	wrapMode         wrap.Mode
 	rollContent      bool
+	maxContent       int
 	disableScrolling bool
 	mouseUpButton    mouse.Button
 	mouseDownButton  mouse.Button
@@ -56,6 +57,7 @@ func newOptions(opts ...Option) *options {
 		keyDown:         DefaultScrollKeyDown,
 		keyPgUp:         DefaultScrollKeyPageUp,
 		keyPgDown:       DefaultScrollKeyPageDown,
+		maxContent:      DefaultMaxContent,
 	}
 	for _, o := range opts {
 		o.set(opt)
@@ -172,5 +174,18 @@ func ScrollKeys(up, down, pageUp, pageDown keyboard.Key) Option {
 		opts.keyDown = down
 		opts.keyPgUp = pageUp
 		opts.keyPgDown = pageDown
+	})
+}
+
+// The default for the maximum buffer length within a content area
+// -1 sets as no limit
+const (
+	DefaultMaxContent = -1
+)
+
+// MaxContent - Limits the maximum content within text widget buffer
+func MaxContent(max int) Option {
+	return option(func(opts *options) {
+		opts.maxContent = max
 	})
 }

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -108,18 +108,24 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 	if opts.replace {
 		t.reset()
 	}
-	for _, r := range text {
-		// Implement basic buffer limit to avoid excess memory issues
-		if len(t.content) > 1 && len(t.content) >= t.opts.maxContent && t.opts.maxContent > 0 {
-			// If the new content is longer than all existing, simply reset
-			if len(string(r)) >= len(t.content) {
-				t.reset()
-			} else {
-				// Truncate by the space required for the new entry
-				t.content = t.content[1:]
-			}
-		}
 
+	// If set, limit the buffer (if maxContent has been set)
+	if len(t.content) >= t.opts.maxContent && t.opts.maxContent > 0 {
+		// If the new content is longer than all existing, simply reset
+		if len(text) >= len(t.content) {
+			t.reset()
+		} else {
+			// Truncate by the space required for the new entry
+			t.content = t.content[len(text):]
+		}
+	}
+
+	// Truncate text as well if it's greater than the maxContent size (if maxContent has been set)
+	if len(text) > t.opts.maxContent && t.opts.maxContent > 0 {
+		text = text[len(text)-t.opts.maxContent:]
+	}
+
+	for _, r := range text {
 		t.content = append(t.content, buffer.NewCell(r, opts.cellOpts))
 	}
 	t.contentChanged = true

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mum4k/termdash/private/canvas"
 	"github.com/mum4k/termdash/private/canvas/buffer"
+	"github.com/mum4k/termdash/private/runewidth"
 	"github.com/mum4k/termdash/private/wrap"
 	"github.com/mum4k/termdash/terminal/terminalapi"
 	"github.com/mum4k/termdash/widgetapi"
@@ -111,18 +112,20 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 
 	// If set, limit the buffer (if maxContent has been set)
 	if len(t.content) >= t.opts.maxContent && t.opts.maxContent > 0 {
+		fmt.Printf("len: %d strlen: %d", len(t.content), len(t.content))
 		// If the new content is longer than all existing, simply reset
 		if len(text) >= len(t.content) {
 			t.reset()
 		} else {
 			// Truncate by the space required for the new entry
-			t.content = t.content[len(text):]
+			t.content = t.content[runewidth.StringWidth(text):]
 		}
 	}
 
 	// Truncate text as well if it's greater than the maxContent size (if maxContent has been set)
-	if len(text) > t.opts.maxContent && t.opts.maxContent > 0 {
-		text = text[len(text)-t.opts.maxContent:]
+	if runewidth.StringWidth(text) > t.opts.maxContent && t.opts.maxContent > 0 {
+		textrunes := []rune(text)
+		text = string(textrunes[len(textrunes)-t.opts.maxContent:])
 	}
 
 	for _, r := range text {

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -109,6 +109,17 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 		t.reset()
 	}
 	for _, r := range text {
+		// Implement basic buffer limit to avoid excess memory issues
+		if len(t.content) > 1 && len(t.content) >= t.opts.maxContent && t.opts.maxContent > 0 {
+			// If the new content is longer than all existing, simply reset
+			if len(string(r)) >= len(t.content) {
+				t.reset()
+			} else {
+				// Truncate by the space required for the new entry
+				t.content = t.content[1:]
+			}
+		}
+
 		t.content = append(t.content, buffer.NewCell(r, opts.cellOpts))
 	}
 	t.contentChanged = true

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -822,9 +822,55 @@ func TestTextDraws(t *testing.T) {
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
 				c := testcanvas.MustNew(ft.Area())
-				// Line return (\n) counts as one character
+				// \n still counts as a chacter in the string length
 				testdraw.MustText(c, "ine3", image.Point{0, 0})
 				testdraw.MustText(c, "line4", image.Point{0, 1})
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent exact length of 5",
+			canvas: image.Rect(0, 0, 10, 1),
+			opts: []Option{
+				RollContent(),
+				MaxContent(5),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("12345")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(
+					c,
+					"12345",
+					image.Point{0, 0},
+				)
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent partial bufffer replacement",
+			canvas: image.Rect(0, 0, 10, 1),
+			opts: []Option{
+				RollContent(),
+				MaxContent(9),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("hello wor你12345678")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(
+					c,
+					"你12345678",
+					image.Point{0, 0},
+				)
 				testcanvas.MustApply(c, ft)
 				return ft
 			},
@@ -836,7 +882,7 @@ func TestTextDraws(t *testing.T) {
 				RollContent(),
 			},
 			writes: func(widget *Text) error {
-				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz")
+				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz")
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -844,7 +890,7 @@ func TestTextDraws(t *testing.T) {
 				// Line return (\n) counts as one character
 				testdraw.MustText(
 					c,
-					"1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz",
+					"1234567890abcdefghijklmnopqrstuvwxyz",
 					image.Point{0, 0},
 				)
 				testcanvas.MustApply(c, ft)

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -809,6 +809,84 @@ func TestTextDraws(t *testing.T) {
 				return ft
 			},
 		},
+		{
+			desc:   "tests maxContent length being applied - multiline",
+			canvas: image.Rect(0, 0, 10, 3),
+			opts: []Option{
+				MaxContent(10),
+				RollContent(),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("line0\nline1\nline2\nline3\nline4")
+			},
+			events: func(widget *Text) {
+				// Draw once to roll the content all the way down before we scroll.
+				if err := widget.Draw(testcanvas.MustNew(image.Rect(0, 0, 10, 3)), &widgetapi.Meta{}); err != nil {
+					panic(err)
+				}
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(c, "ine3", image.Point{0, 0})
+				testdraw.MustText(c, "line4", image.Point{0, 1})
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent length not being limited",
+			canvas: image.Rect(0, 0, 10, 3),
+			opts: []Option{
+				RollContent(),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz")
+			},
+			events: func(widget *Text) {
+				// Draw once to roll the content all the way down before we scroll.
+				if err := widget.Draw(testcanvas.MustNew(image.Rect(0, 0, 10, 3)), &widgetapi.Meta{}); err != nil {
+					panic(err)
+				}
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(
+					c,
+					"1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz",
+					image.Point{0, 1},
+				)
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent length being applied - single line",
+			canvas: image.Rect(0, 0, 10, 3),
+			opts: []Option{
+				MaxContent(5),
+				RollContent(),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz")
+			},
+			events: func(widget *Text) {
+				// Draw once to roll the content all the way down before we scroll.
+				if err := widget.Draw(testcanvas.MustNew(image.Rect(0, 0, 10, 3)), &widgetapi.Meta{}); err != nil {
+					panic(err)
+				}
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				testdraw.MustText(c, "vwxyz", image.Point{0, 0})
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -819,12 +819,6 @@ func TestTextDraws(t *testing.T) {
 			writes: func(widget *Text) error {
 				return widget.Write("line0\nline1\nline2\nline3\nline4")
 			},
-			events: func(widget *Text) {
-				// Draw once to roll the content all the way down before we scroll.
-				if err := widget.Draw(testcanvas.MustNew(image.Rect(0, 0, 10, 3)), &widgetapi.Meta{}); err != nil {
-					panic(err)
-				}
-			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
 				c := testcanvas.MustNew(ft.Area())
@@ -837,18 +831,12 @@ func TestTextDraws(t *testing.T) {
 		},
 		{
 			desc:   "tests maxContent length not being limited",
-			canvas: image.Rect(0, 0, 10, 3),
+			canvas: image.Rect(0, 0, 72, 1),
 			opts: []Option{
 				RollContent(),
 			},
 			writes: func(widget *Text) error {
 				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz")
-			},
-			events: func(widget *Text) {
-				// Draw once to roll the content all the way down before we scroll.
-				if err := widget.Draw(testcanvas.MustNew(image.Rect(0, 0, 10, 3)), &widgetapi.Meta{}); err != nil {
-					panic(err)
-				}
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -857,7 +845,7 @@ func TestTextDraws(t *testing.T) {
 				testdraw.MustText(
 					c,
 					"1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz",
-					image.Point{0, 1},
+					image.Point{0, 0},
 				)
 				testcanvas.MustApply(c, ft)
 				return ft
@@ -872,12 +860,6 @@ func TestTextDraws(t *testing.T) {
 			},
 			writes: func(widget *Text) error {
 				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz")
-			},
-			events: func(widget *Text) {
-				// Draw once to roll the content all the way down before we scroll.
-				if err := widget.Draw(testcanvas.MustNew(image.Rect(0, 0, 10, 3)), &widgetapi.Meta{}); err != nil {
-					panic(err)
-				}
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)


### PR DESCRIPTION
See issue #293 where memory and performance can degrade with a high number of lines written to the Text widget. 

This is a very simplistic implementation to limit the possible length the text buffer can grow to with the `maxContent` option. 

Default value of -1 means there's no limit and therefore behaviour should remain standard.

It has been working in our test app and allows the use of the Text widget to monitor logs (ie tail) and therefore doesn't bloat over time, but happy to adjust as required.