### PR TITLE
Implements a buffer limit for the Text widget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The `Text` widget has a new option `MaxTextCells` which can be used to limit
+  the maximum number of cells the widget keeps in memory.
+
 ### Changed
 
 - Bump github.com/mattn/go-runewidth from 0.0.10 to 0.0.12.

--- a/private/runewidth/runewidth_test.go
+++ b/private/runewidth/runewidth_test.go
@@ -24,6 +24,7 @@ func TestRuneWidth(t *testing.T) {
 	tests := []struct {
 		desc      string
 		runes     []rune
+		opts      []Option
 		eastAsian bool
 		want      int
 	}{
@@ -36,6 +37,14 @@ func TestRuneWidth(t *testing.T) {
 			desc:  "non-printable characters from mattn/runewidth/runewidth_test",
 			runes: []rune{'\x00', '\x01', '\u0300', '\u2028', '\u2029', '\n'},
 			want:  0,
+		},
+		{
+			desc:  "override rune width with an option",
+			runes: []rune{'\n'},
+			opts: []Option{
+				CountAsWidth('\n', 3),
+			},
+			want: 3,
 		},
 		{
 			desc:  "half-width runes from mattn/runewidth/runewidth_test",
@@ -107,7 +116,7 @@ func TestRuneWidth(t *testing.T) {
 			}()
 
 			for _, r := range tc.runes {
-				if got := RuneWidth(r); got != tc.want {
+				if got := RuneWidth(r, tc.opts...); got != tc.want {
 					t.Errorf("RuneWidth(%c, %#x) => %v, want %v", r, r, got, tc.want)
 				}
 			}
@@ -119,6 +128,7 @@ func TestStringWidth(t *testing.T) {
 	tests := []struct {
 		desc      string
 		str       string
+		opts      []Option
 		eastAsian bool
 		want      int
 	}{
@@ -126,6 +136,15 @@ func TestStringWidth(t *testing.T) {
 			desc: "ascii characters",
 			str:  "hello",
 			want: 5,
+		},
+		{
+			desc: "override rune widths with an option",
+			str:  "hello",
+			opts: []Option{
+				CountAsWidth('h', 5),
+				CountAsWidth('e', 5),
+			},
+			want: 13,
 		},
 		{
 			desc: "string from mattn/runewidth/runewidth_test",
@@ -158,7 +177,7 @@ func TestStringWidth(t *testing.T) {
 				runewidth.DefaultCondition.EastAsianWidth = false
 			}()
 
-			if got := StringWidth(tc.str); got != tc.want {
+			if got := StringWidth(tc.str, tc.opts...); got != tc.want {
 				t.Errorf("StringWidth(%q) => %v, want %v", tc.str, got, tc.want)
 			}
 		})

--- a/private/runewidth/runewidth_test.go
+++ b/private/runewidth/runewidth_test.go
@@ -34,7 +34,7 @@ func TestRuneWidth(t *testing.T) {
 		},
 		{
 			desc:  "non-printable characters from mattn/runewidth/runewidth_test",
-			runes: []rune{'\x00', '\x01', '\u0300', '\u2028', '\u2029'},
+			runes: []rune{'\x00', '\x01', '\u0300', '\u2028', '\u2029', '\n'},
 			want:  0,
 		},
 		{

--- a/widgets/text/options.go
+++ b/widgets/text/options.go
@@ -79,6 +79,9 @@ func (o *options) validate() error {
 	if o.mouseUpButton == o.mouseDownButton {
 		return fmt.Errorf("invalid ScrollMouseButtons(up:%v, down:%v), the buttons must be unique", o.mouseUpButton, o.mouseDownButton)
 	}
+	if o.maxTextCells < 0 {
+		return fmt.Errorf("invalid MaxTextCells(%d), must be zero or a positive integer", o.maxTextCells)
+	}
 	return nil
 }
 
@@ -178,9 +181,9 @@ func ScrollKeys(up, down, pageUp, pageDown keyboard.Key) Option {
 }
 
 // The default value for the MaxTextCells option.
-// Use -1 as no limit, for logs you may wish to try 10,000 or higher.
+// Use zero as no limit, for logs you may wish to try 10,000 or higher.
 const (
-	DefaultMaxTextCells = -1
+	DefaultMaxTextCells = 0
 )
 
 // MaxTextCells limits the text content to this number of terminal cells.

--- a/widgets/text/options.go
+++ b/widgets/text/options.go
@@ -36,6 +36,7 @@ type options struct {
 	scrollDown       rune
 	wrapMode         wrap.Mode
 	rollContent      bool
+	maxContent       int
 	disableScrolling bool
 	mouseUpButton    mouse.Button
 	mouseDownButton  mouse.Button
@@ -56,6 +57,7 @@ func newOptions(opts ...Option) *options {
 		keyDown:         DefaultScrollKeyDown,
 		keyPgUp:         DefaultScrollKeyPageUp,
 		keyPgDown:       DefaultScrollKeyPageDown,
+		maxContent:      DefaultMaxContent,
 	}
 	for _, o := range opts {
 		o.set(opt)
@@ -172,5 +174,20 @@ func ScrollKeys(up, down, pageUp, pageDown keyboard.Key) Option {
 		opts.keyDown = down
 		opts.keyPgUp = pageUp
 		opts.keyPgDown = pageDown
+	})
+}
+
+// The default for the maximum buffer length within a content area
+// -1 sets as no limit, for logs you may wish to try 10,000 or higher
+const (
+	DefaultMaxContent = -1
+)
+
+// MaxContent - Limits the maximum content within text widget buffer.
+// This is useful when sending large amounts of text to the Text widget, eg
+// when tailing logs as it will limit the memory usage.
+func MaxContent(max int) Option {
+	return option(func(opts *options) {
+		opts.maxContent = max
 	})
 }

--- a/widgets/text/options.go
+++ b/widgets/text/options.go
@@ -36,7 +36,7 @@ type options struct {
 	scrollDown       rune
 	wrapMode         wrap.Mode
 	rollContent      bool
-	maxContent       int
+	maxTextCells     int
 	disableScrolling bool
 	mouseUpButton    mouse.Button
 	mouseDownButton  mouse.Button
@@ -57,7 +57,7 @@ func newOptions(opts ...Option) *options {
 		keyDown:         DefaultScrollKeyDown,
 		keyPgUp:         DefaultScrollKeyPageUp,
 		keyPgDown:       DefaultScrollKeyPageDown,
-		maxContent:      DefaultMaxContent,
+		maxTextCells:    DefaultMaxTextCells,
 	}
 	for _, o := range opts {
 		o.set(opt)
@@ -177,17 +177,22 @@ func ScrollKeys(up, down, pageUp, pageDown keyboard.Key) Option {
 	})
 }
 
-// The default for the maximum buffer length within a content area
-// -1 sets as no limit, for logs you may wish to try 10,000 or higher
+// The default value for the MaxTextCells option.
+// Use -1 as no limit, for logs you may wish to try 10,000 or higher.
 const (
-	DefaultMaxContent = -1
+	DefaultMaxTextCells = -1
 )
 
-// MaxContent - Limits the maximum content within text widget buffer.
-// This is useful when sending large amounts of text to the Text widget, eg
+// MaxTextCells limits the text content to this number of terminal cells.
+// This is useful when sending large amounts of text to the Text widget, e.g.
 // when tailing logs as it will limit the memory usage.
-func MaxContent(max int) Option {
+// When the newly added content goes over this number of cells, the Text widget
+// behaves as a circular buffer and drops earlier content to accommodate the
+// new one.
+// Note the count is in cells, not runes, some wide runes can take multiple
+// terminal cells.
+func MaxTextCells(max int) Option {
 	return option(func(opts *options) {
-		opts.maxContent = max
+		opts.maxTextCells = max
 	})
 }

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mum4k/termdash/private/canvas"
 	"github.com/mum4k/termdash/private/canvas/buffer"
+	"github.com/mum4k/termdash/private/runewidth"
 	"github.com/mum4k/termdash/private/wrap"
 	"github.com/mum4k/termdash/terminal/terminalapi"
 	"github.com/mum4k/termdash/widgetapi"
@@ -108,6 +109,25 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 	if opts.replace {
 		t.reset()
 	}
+
+	// If set, limit the buffer (if maxContent has been set)
+	if len(t.content) >= t.opts.maxContent && t.opts.maxContent > 0 {
+		fmt.Printf("len: %d strlen: %d", len(t.content), len(t.content))
+		// If the new content is longer than all existing, simply reset
+		if len(text) >= len(t.content) {
+			t.reset()
+		} else {
+			// Truncate by the space required for the new entry
+			t.content = t.content[runewidth.StringWidth(text):]
+		}
+	}
+
+	// Truncate text as well if it's greater than the maxContent size (if maxContent has been set)
+	if runewidth.StringWidth(text) > t.opts.maxContent && t.opts.maxContent > 0 {
+		textrunes := []rune(text)
+		text = string(textrunes[len(textrunes)-t.opts.maxContent:])
+	}
+
 	for _, r := range text {
 		t.content = append(t.content, buffer.NewCell(r, opts.cellOpts))
 	}

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -111,7 +111,7 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 	}
 
 	// If set, limit the buffer (if maxContent has been set)
-	if len(t.content) >= t.opts.maxContent && t.opts.maxContent > 0 {
+	if len(t.content) >= t.opts.maxTextCells && t.opts.maxTextCells > 0 {
 		fmt.Printf("len: %d strlen: %d", len(t.content), len(t.content))
 		// If the new content is longer than all existing, simply reset
 		if len(text) >= len(t.content) {
@@ -123,9 +123,9 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 	}
 
 	// Truncate text as well if it's greater than the maxContent size (if maxContent has been set)
-	if runewidth.StringWidth(text) > t.opts.maxContent && t.opts.maxContent > 0 {
+	if runewidth.StringWidth(text) > t.opts.maxTextCells && t.opts.maxTextCells > 0 {
 		textrunes := []rune(text)
-		text = string(textrunes[len(textrunes)-t.opts.maxContent:])
+		text = string(textrunes[len(textrunes)-t.opts.maxTextCells:])
 	}
 
 	for _, r := range text {

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -97,7 +97,7 @@ func (t *Text) reset() {
 func (t *Text) contentCells() int {
 	cells := 0
 	for _, c := range t.content {
-		cells += runeWidth(c.Rune)
+		cells += runewidth.RuneWidth(c.Rune, runewidth.CountAsWidth('\n', 1))
 	}
 	return cells
 }
@@ -122,7 +122,7 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 	}
 
 	truncated := truncateToCells(text, t.opts.maxTextCells)
-	textCells := stringWidth(truncated)
+	textCells := runewidth.StringWidth(truncated, runewidth.CountAsWidth('\n', 1))
 	contentCells := t.contentCells()
 	// If MaxTextCells has been set, limit the content if needed.
 	if t.opts.maxTextCells > 0 && contentCells+textCells > t.opts.maxTextCells {
@@ -307,29 +307,10 @@ func (t *Text) Options() widgetapi.Options {
 	}
 }
 
-// runeWidth is line runewidth.RuneWidth, but assumes newline characters take 1
-// cell.
-func runeWidth(r rune) int {
-	if r == '\n' {
-		return 1
-	}
-	return runewidth.RuneWidth(r)
-}
-
-// stringWidth is like runewidth.StringWidth, but assumes newline characters
-// take 1 cell.
-func stringWidth(s string) int {
-	var width int
-	for _, r := range []rune(s) {
-		width += runeWidth(r)
-	}
-	return width
-}
-
 // truncateToCells truncates the beginning of text, so that it can be displayed
 // in at most maxCells. Setting maxCells to zero disables truncating.
 func truncateToCells(text string, maxCells int) string {
-	textCells := stringWidth(text)
+	textCells := runewidth.StringWidth(text, runewidth.CountAsWidth('\n', 1))
 	if maxCells == 0 || textCells <= maxCells {
 		return text
 	}
@@ -338,7 +319,7 @@ func truncateToCells(text string, maxCells int) string {
 	textRunes := []rune(text)
 	i := len(textRunes) - 1
 	for ; i >= 0; i-- {
-		haveCells += runeWidth(textRunes[i])
+		haveCells += runewidth.RuneWidth(textRunes[i], runewidth.CountAsWidth('\n', 1))
 		if haveCells > maxCells {
 			break
 		}

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -295,10 +295,29 @@ func (t *Text) Options() widgetapi.Options {
 	}
 }
 
+// runeWidth is line runewidth.RuneWidth, but assumes newline characters take 1
+// cell.
+func runeWidth(r rune) int {
+	if r == '\n' {
+		return 1
+	}
+	return runewidth.RuneWidth(r)
+}
+
+// stringWidth is like runewidth.StringWidth, but assumes newline characters
+// take 1 cell.
+func stringWidth(s string) int {
+	var width int
+	for _, r := range []rune(s) {
+		width += runeWidth(r)
+	}
+	return width
+}
+
 // truncateToCells truncates the beginning of text, so that it can be displayed
 // in at most maxCells. Setting maxCells to zero disables truncating.
 func truncateToCells(text string, maxCells int) string {
-	textCells := runewidth.StringWidth(text)
+	textCells := stringWidth(text)
 	if maxCells == 0 || textCells <= maxCells {
 		return text
 	}
@@ -307,7 +326,7 @@ func truncateToCells(text string, maxCells int) string {
 	textRunes := []rune(text)
 	i := len(textRunes) - 1
 	for ; i >= 0; i-- {
-		haveCells += runewidth.RuneWidth(textRunes[i])
+		haveCells += runeWidth(textRunes[i])
 		if haveCells > maxCells {
 			break
 		}

--- a/widgets/text/text.go
+++ b/widgets/text/text.go
@@ -92,6 +92,16 @@ func (t *Text) reset() {
 	t.contentChanged = true
 }
 
+// contentCells calculates the number of cells the content takes to display on
+// terminal.
+func (t *Text) contentCells() int {
+	cells := 0
+	for _, c := range t.content {
+		cells += runeWidth(c.Rune)
+	}
+	return cells
+}
+
 // Write writes text for the widget to display. Multiple calls append
 // additional text. The text contain cannot control characters
 // (unicode.IsControl) or space character (unicode.IsSpace) other than:
@@ -112,10 +122,12 @@ func (t *Text) Write(text string, wOpts ...WriteOption) error {
 	}
 
 	truncated := truncateToCells(text, t.opts.maxTextCells)
-	textCells := runewidth.StringWidth(truncated)
+	textCells := stringWidth(truncated)
+	contentCells := t.contentCells()
 	// If MaxTextCells has been set, limit the content if needed.
-	if t.opts.maxTextCells > 0 && len(t.content)+textCells > t.opts.maxTextCells {
-		t.content = t.content[len(t.content)-textCells:]
+	if t.opts.maxTextCells > 0 && contentCells+textCells > t.opts.maxTextCells {
+		diff := contentCells + textCells - t.opts.maxTextCells
+		t.content = t.content[diff:]
 	}
 
 	for _, r := range truncated {

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -809,6 +809,112 @@ func TestTextDraws(t *testing.T) {
 				return ft
 			},
 		},
+		{
+			desc:   "tests maxContent length being applied - multiline",
+			canvas: image.Rect(0, 0, 10, 3),
+			opts: []Option{
+				MaxContent(10),
+				RollContent(),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("line0\nline1\nline2\nline3\nline4")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// \n still counts as a chacter in the string length
+				testdraw.MustText(c, "ine3", image.Point{0, 0})
+				testdraw.MustText(c, "line4", image.Point{0, 1})
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent exact length of 5",
+			canvas: image.Rect(0, 0, 10, 1),
+			opts: []Option{
+				RollContent(),
+				MaxContent(5),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("12345")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(
+					c,
+					"12345",
+					image.Point{0, 0},
+				)
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent partial bufffer replacement",
+			canvas: image.Rect(0, 0, 10, 1),
+			opts: []Option{
+				RollContent(),
+				MaxContent(9),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("hello wor你12345678")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(
+					c,
+					"你12345678",
+					image.Point{0, 0},
+				)
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent length not being limited",
+			canvas: image.Rect(0, 0, 72, 1),
+			opts: []Option{
+				RollContent(),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				// Line return (\n) counts as one character
+				testdraw.MustText(
+					c,
+					"1234567890abcdefghijklmnopqrstuvwxyz",
+					image.Point{0, 0},
+				)
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
+		{
+			desc:   "tests maxContent length being applied - single line",
+			canvas: image.Rect(0, 0, 10, 3),
+			opts: []Option{
+				MaxContent(5),
+				RollContent(),
+			},
+			writes: func(widget *Text) error {
+				return widget.Write("1234567890abcdefghijklmnopqrstuvwxyz")
+			},
+			want: func(size image.Point) *faketerm.Terminal {
+				ft := faketerm.MustNew(size)
+				c := testcanvas.MustNew(ft.Area())
+				testdraw.MustText(c, "vwxyz", image.Point{0, 0})
+				testcanvas.MustApply(c, ft)
+				return ft
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -813,7 +813,7 @@ func TestTextDraws(t *testing.T) {
 			desc:   "tests maxContent length being applied - multiline",
 			canvas: image.Rect(0, 0, 10, 3),
 			opts: []Option{
-				MaxContent(10),
+				MaxTextCells(10),
 				RollContent(),
 			},
 			writes: func(widget *Text) error {
@@ -834,7 +834,7 @@ func TestTextDraws(t *testing.T) {
 			canvas: image.Rect(0, 0, 10, 1),
 			opts: []Option{
 				RollContent(),
-				MaxContent(5),
+				MaxTextCells(5),
 			},
 			writes: func(widget *Text) error {
 				return widget.Write("12345")
@@ -857,7 +857,7 @@ func TestTextDraws(t *testing.T) {
 			canvas: image.Rect(0, 0, 10, 1),
 			opts: []Option{
 				RollContent(),
-				MaxContent(9),
+				MaxTextCells(9),
 			},
 			writes: func(widget *Text) error {
 				return widget.Write("hello wor你12345678")
@@ -901,7 +901,7 @@ func TestTextDraws(t *testing.T) {
 			desc:   "tests maxContent length being applied - single line",
 			canvas: image.Rect(0, 0, 10, 3),
 			opts: []Option{
-				MaxContent(5),
+				MaxTextCells(5),
 				RollContent(),
 			},
 			writes: func(widget *Text) error {

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -1007,3 +1007,52 @@ func TestOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateToCells(t *testing.T) {
+	tests := []struct {
+		desc     string
+		text     string
+		maxCells int
+		want     []rune
+	}{
+		{
+			desc:     "returns empty on empty text",
+			text:     "",
+			maxCells: 0,
+			want:     []rune{},
+		},
+		{
+			desc:     "no need to truncate, length matches max",
+			text:     "a",
+			maxCells: 1,
+			want:     []rune{'a'},
+		},
+		{
+			desc:     "no need to truncate, shorter than max",
+			text:     "a",
+			maxCells: 2,
+			want:     []rune{'a'},
+		},
+		{
+			desc:     "no need to truncate, maxCells set to zero",
+			text:     "a",
+			maxCells: 0,
+			want:     []rune{'a'},
+		},
+		{
+			desc:     "truncates to max cells",
+			text:     "abc",
+			maxCells: 2,
+			want:     []rune{'b', 'c'},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := truncateToCells(tc.text, tc.maxCells)
+			if diff := pretty.Compare(tc.want, got); diff != "" {
+				t.Errorf("truncateToCells => unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -822,8 +822,9 @@ func TestTextDraws(t *testing.T) {
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
 				c := testcanvas.MustNew(ft.Area())
-				testdraw.MustText(c, "line3", image.Point{0, 1})
-				testdraw.MustText(c, "line4", image.Point{0, 2})
+				// \n still counts as a chacter in the string length
+				testdraw.MustText(c, "ine3", image.Point{0, 0})
+				testdraw.MustText(c, "line4", image.Point{0, 1})
 				testcanvas.MustApply(c, ft)
 				return ft
 			},
@@ -885,7 +886,6 @@ func TestTextDraws(t *testing.T) {
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
 				c := testcanvas.MustNew(ft.Area())
-				// Line return (\n) counts as one character
 				testdraw.MustText(
 					c,
 					"1234567890abcdefghijklmnopqrstuvwxyz",
@@ -1046,6 +1046,12 @@ func TestTruncateToCells(t *testing.T) {
 		{
 			desc:     "truncates multiple runes to enforce max cells",
 			text:     "abcde",
+			maxCells: 3,
+			want:     "cde",
+		},
+		{
+			desc:     "accounts for cells taken by newline characters",
+			text:     "a\ncde",
 			maxCells: 3,
 			want:     "cde",
 		},

--- a/widgets/text/text_test.go
+++ b/widgets/text/text_test.go
@@ -841,7 +841,6 @@ func TestTextDraws(t *testing.T) {
 					return err
 				}
 				return widget.Write("1\nline2\nline3\nline4")
-				return nil
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)

--- a/widgets/text/textdemo/textdemo.go
+++ b/widgets/text/textdemo/textdemo.go
@@ -122,7 +122,7 @@ func main() {
 		panic(err)
 	}
 
-	rolled, err := text.New(text.RollContent(), text.WrapAtWords())
+	rolled, err := text.New(text.RollContent(), text.WrapAtWords(), text.MaxTextCells(4))
 	if err != nil {
 		panic(err)
 	}

--- a/widgets/text/textdemo/textdemo.go
+++ b/widgets/text/textdemo/textdemo.go
@@ -122,7 +122,7 @@ func main() {
 		panic(err)
 	}
 
-	rolled, err := text.New(text.RollContent(), text.WrapAtWords(), text.MaxTextCells(4))
+	rolled, err := text.New(text.RollContent(), text.WrapAtWords())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
See issue #293 where memory and performance can degrade with a high number of lines written to the Text widget. 

This is a very simplistic implementation to limit the possible length the text buffer can grow to with the `maxContent` option. 

Default value of -1 means there's no limit and therefore behaviour should remain standard.

It has been working in our test app and allows the use of the Text widget to monitor logs (ie tail) and therefore doesn't bloat over time, but happy to adjust as required.