### PR TITLE
Add OnChange handler to the TextInput widget

### DIFF
--- a/widgets/textinput/editor.go
+++ b/widgets/textinput/editor.go
@@ -274,6 +274,9 @@ type fieldEditor struct {
 
 	// width is the width of the text input field last time viewFor was called.
 	width int
+
+	// onChange if provided is the handler called when fieldData changes
+	onChange ChangeFn
 }
 
 // newFieldEditor returns a new fieldEditor instance.
@@ -338,6 +341,9 @@ func (fe *fieldEditor) insert(r rune) {
 	}
 	fe.data.insertAt(fe.curDataPos, r)
 	fe.curDataPos++
+	if fe.onChange != nil {
+		fe.onChange(string(fe.data))
+	}
 }
 
 // delete deletes the rune at the current position of the cursor.
@@ -347,6 +353,9 @@ func (fe *fieldEditor) delete() {
 		return
 	}
 	fe.data.deleteAt(fe.curDataPos)
+	if fe.onChange != nil {
+		fe.onChange(string(fe.data))
+	}
 }
 
 // deleteBefore deletes the rune that is immediately to the left of the cursor.

--- a/widgets/textinput/editor.go
+++ b/widgets/textinput/editor.go
@@ -280,8 +280,8 @@ type fieldEditor struct {
 }
 
 // newFieldEditor returns a new fieldEditor instance.
-func newFieldEditor() *fieldEditor {
-	return &fieldEditor{}
+func newFieldEditor(onChange ChangeFn) *fieldEditor {
+	return &fieldEditor{onChange: onChange}
 }
 
 // minFieldWidth is the minimum supported width of the text input field.
@@ -329,12 +329,7 @@ func (fe *fieldEditor) content() string {
 
 // reset resets the content back to zero.
 func (fe *fieldEditor) reset() {
-	newValue := newFieldEditor()
-	if fe.onChange != nil {
-		fe.onChange("")
-		newValue.onChange = fe.onChange
-	}
-	*fe = *newValue
+	*fe = *newFieldEditor(fe.onChange)
 }
 
 // insert inserts the rune at the current position of the cursor.

--- a/widgets/textinput/editor.go
+++ b/widgets/textinput/editor.go
@@ -329,7 +329,12 @@ func (fe *fieldEditor) content() string {
 
 // reset resets the content back to zero.
 func (fe *fieldEditor) reset() {
-	*fe = *newFieldEditor()
+	newValue := newFieldEditor()
+	if fe.onChange != nil {
+		fe.onChange("")
+		newValue.onChange = fe.onChange
+	}
+	*fe = *newValue
 }
 
 // insert inserts the rune at the current position of the cursor.

--- a/widgets/textinput/editor_test.go
+++ b/widgets/textinput/editor_test.go
@@ -330,6 +330,7 @@ func TestFieldEditor(t *testing.T) {
 		wantContent string
 		wantCurIdx  int
 		wantErr     bool
+		mutations   int
 	}{
 		{
 			desc:    "fails for width too small",
@@ -355,6 +356,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  3,
+			mutations:   3,
 		},
 		{
 			desc:  "longer data than the width, cursor at the end",
@@ -369,6 +371,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd",
 			wantContent: "abcd",
 			wantCurIdx:  3,
+			mutations:   4,
 		},
 		{
 			desc:  "longer data than the width, cursor at the end, has full-width runes",
@@ -383,6 +386,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦世",
 			wantContent: "abc世",
 			wantCurIdx:  3,
+			mutations:   4,
 		},
 		{
 			desc:  "width decreased, adjusts cursor and shifts data",
@@ -400,6 +404,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd",
 			wantContent: "abcd",
 			wantCurIdx:  3,
+			mutations:   4,
 		},
 		{
 			desc:  "cursor won't go right beyond the end of the data",
@@ -417,6 +422,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd",
 			wantContent: "abcd",
 			wantCurIdx:  3,
+			mutations:   4,
 		},
 		{
 			desc:  "moves cursor to the left",
@@ -435,6 +441,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd",
 			wantContent: "abcd",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "scrolls content to the left, start becomes visible",
@@ -455,6 +462,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc⇨",
 			wantContent: "abcd",
 			wantCurIdx:  1,
+			mutations:   4,
 		},
 		{
 			desc:  "scrolls content to the left, both ends invisible",
@@ -476,6 +484,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd⇨",
 			wantContent: "abcde",
 			wantCurIdx:  1,
+			mutations:   5,
 		},
 		{
 			desc:  "scrolls left, then back right to make end visible again",
@@ -503,6 +512,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦de",
 			wantContent: "abcde",
 			wantCurIdx:  3,
+			mutations:   5,
 		},
 		{
 			desc:  "scrolls left, won't go beyond the start of data",
@@ -527,6 +537,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc⇨",
 			wantContent: "abcde",
 			wantCurIdx:  0,
+			mutations:   5,
 		},
 		{
 			desc:  "scrolls left, then back right won't go beyond the end of data",
@@ -555,6 +566,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦de",
 			wantContent: "abcde",
 			wantCurIdx:  3,
+			mutations:   5,
 		},
 		{
 			desc:  "have less data than width, all fits",
@@ -571,6 +583,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  3,
+			mutations:   3,
 		},
 		{
 			desc:  "moves cursor to the start",
@@ -590,6 +603,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc⇨",
 			wantContent: "abcde",
 			wantCurIdx:  0,
+			mutations:   5,
 		},
 		{
 			desc:  "moves cursor to the end",
@@ -613,6 +627,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦de",
 			wantContent: "abcde",
 			wantCurIdx:  3,
+			mutations:   5,
 		},
 		{
 			desc:  "deletesBefore when cursor after the data",
@@ -632,6 +647,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd",
 			wantContent: "abcd",
 			wantCurIdx:  3,
+			mutations:   6,
 		},
 		{
 			desc:  "deletesBefore when cursor after the data, text has full-width rune",
@@ -651,6 +667,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦世",
 			wantContent: "abc世",
 			wantCurIdx:  3,
+			mutations:   6,
 		},
 		{
 			desc:  "deletesBefore when cursor in the middle",
@@ -676,6 +693,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "acd⇨",
 			wantContent: "acde",
 			wantCurIdx:  1,
+			mutations:   6,
 		},
 		{
 			desc:  "deletesBefore when cursor in the middle, full-width runes",
@@ -701,6 +719,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "世c⇨",
 			wantContent: "世cde",
 			wantCurIdx:  2,
+			mutations:   6,
 		},
 		{
 			desc:  "deletesBefore does nothing when cursor at the start",
@@ -724,6 +743,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc⇨",
 			wantContent: "abcde",
 			wantCurIdx:  0,
+			mutations:   5,
 		},
 		{
 			desc:  "delete does nothing when cursor at the end",
@@ -743,6 +763,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦de",
 			wantContent: "abcde",
 			wantCurIdx:  3,
+			mutations:   5,
 		},
 		{
 			desc:  "delete in the middle, last rune remains hidden",
@@ -767,6 +788,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "acd⇨",
 			wantContent: "acde",
 			wantCurIdx:  1,
+			mutations:   6,
 		},
 		{
 			desc:  "delete in the middle, last rune becomes visible",
@@ -792,6 +814,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "ade",
 			wantContent: "ade",
 			wantCurIdx:  1,
+			mutations:   7,
 		},
 		{
 			desc:  "delete in the middle, last full-width rune would be invisible, shifts to keep cursor in window",
@@ -818,6 +841,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦世",
 			wantContent: "ab世",
 			wantCurIdx:  1,
+			mutations:   7,
 		},
 		{
 			desc:  "delete in the middle, last rune was and is visible",
@@ -840,6 +864,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "ac",
 			wantContent: "ac",
 			wantCurIdx:  1,
+			mutations:   4,
 		},
 		{
 			desc:  "delete in the middle, last full-width rune was and is visible",
@@ -862,6 +887,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "a世",
 			wantContent: "a世",
 			wantCurIdx:  1,
+			mutations:   4,
 		},
 		{
 			desc:  "delete last rune, contains full-width runes",
@@ -885,6 +911,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "",
 			wantContent: "",
 			wantCurIdx:  0,
+			mutations:   6,
 		},
 		{
 			desc:  "half-width runes only, exact fit",
@@ -901,6 +928,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  3,
+			mutations:   3,
 		},
 		{
 			desc:  "full-width runes only, exact fit",
@@ -917,6 +945,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "你好世",
 			wantContent: "你好世",
 			wantCurIdx:  6,
+			mutations:   3,
 		},
 		{
 			desc:  "half-width runes only, both ends hidden",
@@ -938,6 +967,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd⇨",
 			wantContent: "abcde",
 			wantCurIdx:  1,
+			mutations:   5,
 		},
 		{
 			desc:  "half-width runes only, both ends invisible, scrolls to make start visible",
@@ -960,6 +990,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc⇨",
 			wantContent: "abcde",
 			wantCurIdx:  1,
+			mutations:   5,
 		},
 		{
 			desc:  "half-width runes only, both ends invisible, deletes to make start visible",
@@ -982,6 +1013,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "acd⇨",
 			wantContent: "acde",
 			wantCurIdx:  1,
+			mutations:   6,
 		},
 		{
 			desc:  "half-width runes only, deletion on second page refills the field",
@@ -1004,6 +1036,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦df",
 			wantContent: "abcdf",
 			wantCurIdx:  2,
+			mutations:   7,
 		},
 		{
 			desc:  "half-width runes only, both ends invisible, scrolls to make end visible",
@@ -1030,6 +1063,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦de",
 			wantContent: "abcde",
 			wantCurIdx:  2,
+			mutations:   5,
 		},
 		{
 			desc:  "half-width runes only, both ends invisible, deletes to make end visible",
@@ -1055,6 +1089,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦de",
 			wantContent: "abde",
 			wantCurIdx:  1,
+			mutations:   6,
 		},
 		{
 			desc:  "full-width runes only, both ends invisible",
@@ -1074,6 +1109,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦世⇨",
 			wantContent: "你好世界",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "full-width runes only, both ends invisible, scrolls to make start visible",
@@ -1097,6 +1133,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "你好⇨",
 			wantContent: "你好世界",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "full-width runes only, both ends invisible, deletes to make start visible",
@@ -1120,6 +1157,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "你世⇨",
 			wantContent: "你世界",
 			wantCurIdx:  2,
+			mutations:   5,
 		},
 		{
 			desc:  "full-width runes only, both ends invisible, scrolls to make end visible",
@@ -1143,6 +1181,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦界",
 			wantContent: "你好世界",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "full-width runes only, both ends invisible, deletes to make end visible",
@@ -1166,6 +1205,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦界",
 			wantContent: "你好界",
 			wantCurIdx:  2,
+			mutations:   5,
 		},
 		{
 			desc:  "scrolls to make full-width rune appear at the beginning",
@@ -1186,6 +1226,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "你b⇨",
 			wantContent: "你bcd",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "scrolls to make full-width rune appear at the end",
@@ -1207,6 +1248,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦你",
 			wantContent: "abc你",
 			wantCurIdx:  1,
+			mutations:   4,
 		},
 		{
 			desc:  "inserts after last full width rune, first is half-width",
@@ -1225,6 +1267,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦c你e",
 			wantContent: "abc你e",
 			wantCurIdx:  5,
+			mutations:   5,
 		},
 		{
 			desc:  "inserts after last full width rune, first is half-width",
@@ -1242,6 +1285,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦你d",
 			wantContent: "世b你d",
 			wantCurIdx:  4,
+			mutations:   4,
 		},
 		{
 			desc:  "inserts after last full width rune, hidden rune is full-width",
@@ -1259,6 +1303,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦cd",
 			wantContent: "世你cd",
 			wantCurIdx:  4,
+			mutations:   4,
 		},
 		{
 			desc:  "scrolls right, first is full-width, last are half-width",
@@ -1285,6 +1330,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦def⇨",
 			wantContent: "a你世defgh",
 			wantCurIdx:  3,
+			mutations:   8,
 		},
 		{
 			desc:  "scrolls right, first is half-width, last is full-width",
@@ -1311,6 +1357,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦你世⇨",
 			wantContent: "abc你世fgh",
 			wantCurIdx:  3,
+			mutations:   8,
 		},
 		{
 			desc:  "scrolls right, first and last are full-width",
@@ -1331,6 +1378,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦世⇨",
 			wantContent: "你好世界",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "scrolls right, first and last are half-width",
@@ -1357,6 +1405,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cdef⇨",
 			wantContent: "abcdefg",
 			wantCurIdx:  4,
+			mutations:   7,
 		},
 		{
 			desc:  "scrolls left, first is full-width, last are half-width",
@@ -1383,6 +1432,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦def⇨",
 			wantContent: "a你世defgh",
 			wantCurIdx:  2,
+			mutations:   8,
 		},
 		{
 			desc:  "scrolls left, first is half-width, last is full-width",
@@ -1409,6 +1459,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦你世⇨",
 			wantContent: "abc你世fgh",
 			wantCurIdx:  1,
+			mutations:   8,
 		},
 		{
 			desc:  "scrolls left, first and last are full-width",
@@ -1428,6 +1479,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦世⇨",
 			wantContent: "你好世界",
 			wantCurIdx:  2,
+			mutations:   4,
 		},
 		{
 			desc:  "scrolls left, first and last are half-width",
@@ -1453,6 +1505,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cdef⇨",
 			wantContent: "abcdefg",
 			wantCurIdx:  1,
+			mutations:   7,
 		},
 		{
 			desc:  "resets the field editor",
@@ -1470,6 +1523,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "",
 			wantContent: "",
 			wantCurIdx:  0,
+			mutations:   3,
 		},
 		{
 			desc:  "doesn't insert runes with rune width of zero",
@@ -1486,6 +1540,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "ac",
 			wantContent: "ac",
 			wantCurIdx:  2,
+			mutations:   2,
 		},
 		{
 			desc:  "all text visible, moves cursor to position zero",
@@ -1503,6 +1558,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  0,
+			mutations:   3,
 		},
 		{
 			desc:  "all text visible, moves cursor to position in the middle",
@@ -1520,6 +1576,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  1,
+			mutations:   3,
 		},
 		{
 			desc:  "all text visible, moves cursor back to the last character",
@@ -1538,6 +1595,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  2,
+			mutations:   3,
 		},
 		{
 			desc:  "all text visible, moves cursor to the appending space",
@@ -1556,6 +1614,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  3,
+			mutations:   3,
 		},
 		{
 			desc:  "all text visible, moves cursor before the beginning of data",
@@ -1574,6 +1633,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  0,
+			mutations:   3,
 		},
 		{
 			desc:  "all text visible, moves cursor after the appending space",
@@ -1592,6 +1652,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "abc",
 			wantContent: "abc",
 			wantCurIdx:  3,
+			mutations:   3,
 		},
 		{
 			desc:  "moves cursor when there is no text",
@@ -1629,6 +1690,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd⇨",
 			wantContent: "abcde",
 			wantCurIdx:  1,
+			mutations:   5,
 		},
 		{
 			desc:  "both ends hidden, moves cursor onto the first character",
@@ -1655,6 +1717,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd⇨",
 			wantContent: "abcde",
 			wantCurIdx:  1,
+			mutations:   5,
 		},
 		{
 			desc:  "both ends hidden, moves cursor onto the right arrow",
@@ -1680,6 +1743,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd⇨",
 			wantContent: "abcde",
 			wantCurIdx:  2,
+			mutations:   5,
 		},
 		{
 			desc:  "both ends hidden, moves cursor onto the last character",
@@ -1705,6 +1769,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦cd⇨",
 			wantContent: "abcde",
 			wantCurIdx:  2,
+			mutations:   5,
 		},
 		{
 			desc:  "moves cursor onto the first cell containing a full-width rune",
@@ -1730,6 +1795,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦世界⇨",
 			wantContent: "你好世界你",
 			wantCurIdx:  4,
+			mutations:   5,
 		},
 		{
 			desc:  "moves cursor onto the second cell containing a full-width rune",
@@ -1755,6 +1821,7 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦世界⇨",
 			wantContent: "你好世界你",
 			wantCurIdx:  4,
+			mutations:   5,
 		},
 		{
 			desc:  "moves cursor onto the second right arrow",
@@ -1780,12 +1847,18 @@ func TestFieldEditor(t *testing.T) {
 			wantView:    "⇦⇦世界⇨",
 			wantContent: "你好世界你",
 			wantCurIdx:  2,
+			mutations:   5,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			fe := newFieldEditor()
+			var changeCount int
+			fe.onChange = func(data string) {
+				changeCount++
+			}
+
 			if tc.ops != nil {
 				if err := tc.ops(fe); err != nil {
 					t.Fatalf("ops => unexpected error: %v", err)
@@ -1807,6 +1880,10 @@ func TestFieldEditor(t *testing.T) {
 			gotContent := fe.content()
 			if gotContent != tc.wantContent {
 				t.Errorf("content -> %q, want %q", gotContent, tc.wantContent)
+			}
+
+			if tc.mutations != changeCount {
+				t.Errorf("mutation count -> %d, want %d", changeCount, tc.mutations)
 			}
 		})
 	}

--- a/widgets/textinput/options.go
+++ b/widgets/textinput/options.go
@@ -63,6 +63,7 @@ type options struct {
 
 	filter                   FilterFn
 	onSubmit                 SubmitFn
+	onChange                 ChangeFn
 	clearOnSubmit            bool
 	exclusiveKeyboardOnFocus bool
 }
@@ -266,6 +267,19 @@ type SubmitFn func(text string) error
 func OnSubmit(fn SubmitFn) Option {
 	return option(func(opts *options) {
 		opts.onSubmit = fn
+	})
+}
+
+// ChangeFn if provided is called when the content of the text input field changes,
+// the argument data contains all the text in the field.
+//
+// The callback function must be thread-safe as the keyboard event that
+// triggers the submission comes from a separate goroutine.
+type ChangeFn func(data string)
+
+func OnChange(fn ChangeFn) Option {
+	return option(func(opts *options) {
+		opts.onChange = fn
 	})
 }
 

--- a/widgets/textinput/options.go
+++ b/widgets/textinput/options.go
@@ -270,13 +270,14 @@ func OnSubmit(fn SubmitFn) Option {
 	})
 }
 
-// ChangeFn if provided is called when the content of the text input field changes,
-// the argument data contains all the text in the field.
+// The argument to ChangeFn contains all the text in the field after the change.
 //
 // The callback function must be thread-safe as the keyboard event that
 // triggers the submission comes from a separate goroutine.
 type ChangeFn func(data string)
 
+// OnChange sets a function that will be called when the content of the text input
+// field changes.
 func OnChange(fn ChangeFn) Option {
 	return option(func(opts *options) {
 		opts.onChange = fn

--- a/widgets/textinput/textinput.go
+++ b/widgets/textinput/textinput.go
@@ -70,10 +70,9 @@ func New(opts ...Option) (*TextInput, error) {
 		return nil, err
 	}
 	ti := &TextInput{
-		editor: newFieldEditor(),
+		editor: newFieldEditor(opt.onChange),
 		opts:   opt,
 	}
-	ti.editor.onChange = opt.onChange
 	for _, r := range ti.opts.defaultText {
 		ti.editor.insert(r)
 	}

--- a/widgets/textinput/textinput.go
+++ b/widgets/textinput/textinput.go
@@ -73,7 +73,7 @@ func New(opts ...Option) (*TextInput, error) {
 		editor: newFieldEditor(),
 		opts:   opt,
 	}
-
+	ti.editor.onChange = opt.onChange
 	for _, r := range ti.opts.defaultText {
 		ti.editor.insert(r)
 	}

--- a/widgets/textinput/textinputdemo/textinputdemo.go
+++ b/widgets/textinput/textinputdemo/textinputdemo.go
@@ -200,7 +200,7 @@ func main() {
 				grid.Widget(
 					mirror,
 					container.Border(linestyle.Light),
-					container.BorderTitle("text"),
+					container.BorderTitle("Text"),
 					container.AlignHorizontal(align.HorizontalCenter),
 					container.AlignHorizontal(align.Horizontal(align.VerticalBottom)),
 					container.MarginBottom(1),

--- a/widgets/textinput/textinputdemo/textinputdemo.go
+++ b/widgets/textinput/textinputdemo/textinputdemo.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mum4k/termdash/terminal/tcell"
 	"github.com/mum4k/termdash/widgets/button"
 	"github.com/mum4k/termdash/widgets/segmentdisplay"
+	"github.com/mum4k/termdash/widgets/text"
 	"github.com/mum4k/termdash/widgets/textinput"
 )
 
@@ -126,11 +127,20 @@ func main() {
 	updateText := make(chan string)
 	go rollText(ctx, rollingSD, updateText)
 
+	mirror, err := text.New()
+	if err != nil {
+		panic(err)
+	}
+
 	input, err := textinput.New(
 		textinput.Label("New text:", cell.FgColor(cell.ColorNumber(33))),
 		textinput.MaxWidthCells(20),
 		textinput.Border(linestyle.Light),
 		textinput.PlaceHolder("Enter any text"),
+		textinput.OnChange(func(data string) {
+			mirror.Reset()
+			mirror.Write(data)
+		}),
 	)
 	if err != nil {
 		panic(err)
@@ -177,18 +187,30 @@ func main() {
 		),
 	)
 	builder.Add(
-		grid.RowHeightPerc(20,
-			grid.Widget(
-				input,
-				container.AlignHorizontal(align.HorizontalCenter),
-				container.AlignVertical(align.VerticalBottom),
-				container.MarginBottom(1),
+		grid.RowHeightPerc(40,
+			grid.RowHeightPerc(50,
+				grid.Widget(
+					input,
+					container.AlignHorizontal(align.HorizontalCenter),
+					container.AlignVertical(align.VerticalBottom),
+					container.MarginBottom(1),
+				),
+			),
+			grid.RowHeightPerc(50,
+				grid.Widget(
+					mirror,
+					container.Border(linestyle.Light),
+					container.BorderTitle("text"),
+					container.AlignHorizontal(align.HorizontalCenter),
+					container.AlignHorizontal(align.Horizontal(align.VerticalBottom)),
+					container.MarginBottom(1),
+				),
 			),
 		),
 	)
 
 	builder.Add(
-		grid.RowHeightPerc(40,
+		grid.RowHeightPerc(20,
 			grid.ColWidthPerc(20),
 			grid.ColWidthPerc(20,
 				grid.Widget(


### PR DESCRIPTION
This PR adds an `onChange` option to the TextInput widget. This is an event handler similar to the existing `OnSubmit`, it is called whenever a character is inserted or deleted from the TextInput's text content.

Rudimentary tests have been written and an example of it's usage is given in `textinputdemo.go`.