### PR TITLE
Implement backtab for tcell widgets

### DIFF
--- a/container/container_test.go
+++ b/container/container_test.go
@@ -1939,7 +1939,7 @@ func TestMouse(t *testing.T) {
 						),
 						Right(
 							PlaceWidget(fakewidget.New(widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused})),
-							KeyFocusPrevious(keyboard.KeyTab),
+							KeyFocusPrevious(keyboard.KeyBacktab),
 						),
 					),
 				)
@@ -1949,7 +1949,7 @@ func TestMouse(t *testing.T) {
 				return c, nil
 			},
 			events: []terminalapi.Event{
-				&terminalapi.Keyboard{Key: keyboard.KeyTab},
+				&terminalapi.Keyboard{Key: keyboard.KeyBacktab},
 			},
 			want: func(size image.Point) *faketerm.Terminal {
 				ft := faketerm.MustNew(size)
@@ -1966,7 +1966,7 @@ func TestMouse(t *testing.T) {
 					&widgetapi.Meta{Focused: true},
 					widgetapi.Options{WantKeyboard: widgetapi.KeyScopeFocused},
 					&fakewidget.Event{
-						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyTab},
+						Ev:   &terminalapi.Keyboard{Key: keyboard.KeyBacktab},
 						Meta: &widgetapi.EventMeta{Focused: true},
 					},
 				)

--- a/container/focus_test.go
+++ b/container/focus_test.go
@@ -529,7 +529,7 @@ func TestFocusTrackerNextAndPrevious(t *testing.T) {
 
 	const (
 		keyNext     keyboard.Key = keyboard.KeyTab
-		keyPrevious keyboard.Key = '~'
+		keyPrevious keyboard.Key = keyboard.KeyBacktab
 	)
 
 	tests := []struct {

--- a/keyboard/keyboard.go
+++ b/keyboard/keyboard.go
@@ -65,6 +65,7 @@ var buttonNames = map[Key]string{
 	KeyCtrlG:      "KeyCtrlG",
 	KeyBackspace:  "KeyBackspace",
 	KeyTab:        "KeyTab",
+	KeyBacktab:    "KeyBacktab",
 	KeyCtrlJ:      "KeyCtrlJ",
 	KeyCtrlK:      "KeyCtrlK",
 	KeyCtrlL:      "KeyCtrlL",
@@ -130,6 +131,7 @@ const (
 	KeyCtrlG
 	KeyBackspace
 	KeyTab
+	KeyBacktab
 	KeyCtrlJ
 	KeyCtrlK
 	KeyCtrlL

--- a/terminal/tcell/event.go
+++ b/terminal/tcell/event.go
@@ -77,6 +77,7 @@ var tcellToTd = map[tcell.Key]keyboard.Key{
 	tcell.KeyCtrlZ:          keyboard.KeyCtrlZ,
 	tcell.KeyBackspace:      keyboard.KeyBackspace,
 	tcell.KeyTab:            keyboard.KeyTab,
+	tcell.KeyBacktab:        keyboard.KeyBacktab,
 	tcell.KeyEscape:         keyboard.KeyEsc,
 	tcell.KeyCtrlBackslash:  keyboard.KeyCtrlBackslash,
 	tcell.KeyCtrlRightSq:    keyboard.KeyCtrlRsqBracket,

--- a/terminal/tcell/event_test.go
+++ b/terminal/tcell/event_test.go
@@ -218,6 +218,7 @@ func TestKeyboardKeys(t *testing.T) {
 		{key: tcell.KeyBackspace, want: keyboard.KeyCtrlH},
 		{key: tcell.KeyCtrlH, want: keyboard.KeyBackspace},
 		{key: tcell.KeyTab, want: keyboard.KeyTab},
+		{key: tcell.KeyBacktab, want: keyboard.KeyBacktab},
 		{key: tcell.KeyTab, want: keyboard.KeyCtrlI},
 		{key: tcell.KeyCtrlI, want: keyboard.KeyTab},
 		{key: tcell.KeyCtrlJ, want: keyboard.KeyCtrlJ},

--- a/widgets/textinput/formdemo/formdemo.go
+++ b/widgets/textinput/formdemo/formdemo.go
@@ -167,6 +167,7 @@ func newForm(cancel context.CancelFunc) (*form, error) {
 func formLayout(c *container.Container, f *form) error {
 	return c.Update("root",
 		container.KeyFocusNext(keyboard.KeyTab),
+		container.KeyFocusPrevious(keyboard.KeyBacktab),
 		container.KeyFocusGroupsNext(keyboard.KeyArrowDown, 1),
 		container.KeyFocusGroupsPrevious(keyboard.KeyArrowUp, 1),
 		container.KeyFocusGroupsNext(keyboard.KeyArrowRight, 2),


### PR DESCRIPTION
This implements "Backtab" (a.k.a. Shift+Tab) as a supported keystroke for tcell widgets. Uses backtab in a few tests and demos as makes sense.