### PR TITLE
[FEAT] reset for linechart

### DIFF
--- a/widgets/linechart/linechart.go
+++ b/widgets/linechart/linechart.go
@@ -232,6 +232,13 @@ func (lc *LineChart) Series(label string, values []float64, opts ...SeriesOption
 	return nil
 }
 
+func (lc *LineChart) Reset() {
+	if lc == nil {
+		return
+	}
+	lc.series = make(map[string]*seriesValues)
+}
+
 // xDetails returns the details for the X axis given the specified minimum and
 // maximum value to display.
 func (lc *LineChart) xDetails(cvs *canvas.Canvas, reqYWidth, min, max int) (*axes.XDetails, error) {


### PR DESCRIPTION
I create a linechart for prometheus metrics,  and when i change the PromQL in inputtest, i need draw a total different linechart.
For example:

1. First i create a linechart with PromQL: `node_receive_packet_total{}`
2. Seconde i change the PromQL to : `rate(node_receive_packet_total{}[1m])`
That is the total different graph , so i need to reset the current graph ,and draw new one