### PR TITLE
Add AI agent rules setup

### DIFF
--- a/.agents/rules/001-persistent-rules.md
+++ b/.agents/rules/001-persistent-rules.md
@@ -1,0 +1,29 @@
+---
+trigger: always_on
+description: Foundational AI agent operating rules for the termdash repository
+globs: *
+---
+
+# Persistent Rules
+
+## Rule Loading
+
+Rules located in `.agents/rules/` are the authoritative set of operating boundaries for any AI agent working in this repository.
+
+These rules establish the foundational operating boundaries for the repository. Under no circumstances should the agent ignore, bypass, or selectively apply these rules unless explicitly commanded by the user with a manual override.
+
+### Rule File Format
+All new rules must be created as standard `.md` files in `.agents/rules/`. 
+
+To ensure Cursor loads these rules automatically, **every rule must have a corresponding `.mdc` symlink inside `.cursor/rules/`**. When creating or adding a new rule file `[name].md`, you MUST also create the symlink:
+`ln -s ../../.agents/rules/[name].md .cursor/rules/[name].mdc`
+
+All newly added rule files MUST contain a YAML frontmatter header at the very top of the file in the following format:
+
+```yaml
+---
+trigger: always_on
+description: [Short rule description]
+globs: *
+---
+```

--- a/.agents/rules/002-documentation.md
+++ b/.agents/rules/002-documentation.md
@@ -1,0 +1,16 @@
+---
+trigger: always_on
+alwaysApply: true
+description: When and how to update project documentation
+globs: *
+---
+
+# Documentation
+
+- **Update docs on each major change.** When you:
+  - Add or remove a dependency or build requirement: update `README.md` and `CONTRIBUTING.md` as relevant.
+  - Add or change a widget, public API surface, or drawing primitive: update the relevant package-level doc comments and `README.md` widget listing.
+  - Remove a feature or deprecate a public API: update all references in README, CHANGELOG, doc/ files, and code comments.
+  - Introduce a new concept or pattern (e.g. new widget category, new drawing primitive): add documentation in `doc/` so future contributors (and AI) know the intended design.
+- **Docs to maintain:** `README.md` (quick start, widget listing, badges), `CONTRIBUTING.md` (fork/merge workflow, CLA), `CHANGELOG.md` (version history), `doc/` directory (design goals, guidelines, HLD, widget development guide).
+- **Agent rules:** When making an important decision that should be followed in future work (e.g. conventions, patterns, "always do X" or "never do Y"), update rules in `.agents/rules/` so that AI and contributors consistently apply it. Add or adjust a rule in the appropriate file rather than relying on one-off comments or memory.

--- a/.agents/rules/005-git-workflow.md
+++ b/.agents/rules/005-git-workflow.md
@@ -1,0 +1,53 @@
+---
+trigger: always_on
+description: Git workflow, branching policy, and safety rules
+globs: *
+alwaysApply: true
+---
+
+# Rule: git-workflow
+
+## Git Version Control, Safety & Review Process
+
+To protect the integrity of the project code and ensure effective review of logic changes, the AI agent must adhere strictly to the following Git workflow and safety procedures.
+
+### Branching Policy
+
+The agent is explicitly forbidden from committing work directly to the `master` or `devel` branches.
+
+**Termdash uses the [nvie branching model](https://nvie.com/posts/a-successful-git-branching-model/).** All development happens on the `devel` branch. Feature branches must be based off `devel` and PRs must target `devel`. The `master` branch is reserved for releases, major bug fixes, and documentation updates.
+
+Whenever a new feature, iteration, or rule modification is requested by the user, the agent must:
+1. Check if there is already an active feature branch we are iterating on for the current session or logical feature. If so, **you MUST checkout, reuse it, and push to it.** Do NOT create a new branch/PR for every single follow-up prompt or UI tweak.
+2. If there truly isn't an active feature branch, create and checkout a new feature branch using `git checkout -b feature/[short-description] devel`. **NEVER create multiple feature branches for a single logical set of updates or consecutive user requests. Consolidate them into one branch.**
+3. Create a GitHub Pull Request (PR) for the branch targeting `devel` if it doesn't already exist.
+4. Perform all research, modifications, rule generations, and script edits on that single unified feature branch.
+
+The user mandates a strict **One Branch / One PR Policy** for all ongoing work.
+
+Whenever taking action, the agent MUST:
+1. Keep exactly **one** unified feature branch open (e.g., `feature/current-updates`) for the entirety of the conversational session or block of work.
+2. **Never create multiple feature branches or Pull Requests.** Push all incremental modifications, completely distinct files, and entirely different features directly to that single, unified active branch.
+3. Create one GitHub Pull Request (PR) for everything, and just keep adding commits to it.
+4. DO NOT create "per-task" branches. The user explicitly only wants one feature branch and one PR to review at a time.
+
+### Git Safety and Failure Handling
+1. **No Force Pushing**: The agent is STRICTLY FORBIDDEN from ever using `--force` or `-f` flags when pushing to any remote branch (`git push --force`, `git push -f`).
+2. **No Force Committing**: The agent is STRICTLY FORBIDDEN from bypassing git hooks using the `--no-verify` flag during commits (`git commit --no-verify`), unless explicitly instructed by the user.
+3. **Failure Handling**: If a `git commit` or `git push` command fails for any reason (e.g., pre-push hook fails, branch conflicts, test script failures), the agent MUST STOP and immediately ask the user how to proceed.
+4. **Resolution**: The agent should present the error output to the user and await explicit instructions rather than attempting to force the git operation through.
+
+### Review via Pull Requests
+When the agent has completed the iteration on the feature branch:
+1. Stage and commit the changes (`git add . && git commit -m "..."`).
+2. Push the feature branch to the remote repository.
+3. Notify the user that the branch is ready for review.
+4. **CRITICAL: NEVER automatically merge the PR (`gh pr merge`) into `devel` or `master` unless the user explicitly gives you the command to do so.** You must stop and wait for their review feedback.
+5. **Post-Merge Cleanup**: When the user explicitly gives you permission to merge the PR, you MUST clean up both local and remote feature branches immediately after merging (e.g., `git push origin --delete branch-name` and `git branch -D branch-name`). Do not leave orphaned feature branches in the local or remote environments.
+
+### Processing Review Feedback
+If the user requests changes via GitHub PR comments:
+1. Methodically address each comment directly in the codebase or rules.
+2. Once pushed, explicitly acknowledge every addressed comment so the user can smoothly track your resolution status.
+
+**Only if the user explicitly inputs a manual override command** (e.g., "you may commit directly to devel this one time") is the agent allowed to bypass this safety protocol. Otherwise, feature branches must be isolated and submitted for PR review.

--- a/.agents/rules/006-go-best-practices.md
+++ b/.agents/rules/006-go-best-practices.md
@@ -1,0 +1,17 @@
+---
+trigger: always_on
+alwaysApply: true
+description: Go best practices for termdash library code
+globs: "**/*.go"
+---
+
+# Go Best Practices
+
+- **Idiomatic Go:** Follow standard Go style (effective go, gofmt). Use clear names and small, focused functions.
+- **Error handling:** Always handle errors explicitly; never ignore them. Return errors to callers or handle them meaningfully. Use Go's standard `errors` and `fmt.Errorf` with `%w` for wrapping.
+- **Readability first:** Termdash's primary design goal is code readability. The functionality and efficiency come second. Write code that is easy to understand, enhance, and test.
+- **Widget separation:** Widget implementations should contain high-level code only. Low-level drawing primitives belong in separate packages (e.g., `private/draw/`). See `doc/design_guidelines.md`.
+- **Test helpers:** Provide test helpers (e.g., `MustRectangle()`) for all functions in the draw package to simplify widget unit tests.
+- **Public vs Private:** Private packages live under `private/` and are identified by the presence of `/private/` in their import path. Stability of private packages isn't guaranteed. Public API surface is documented in the wiki.
+- **Concurrency:** When writing concurrent code, prefer clear synchronization patterns (mutexes, channels). Ensure proper locking and avoid data races — the project runs tests with the race detector.
+- **Performance:** Avoid unnecessary allocations in hot paths (e.g., drawing loops, event processing). Prefer bounded operations and avoid O(n²) patterns where linear alternatives exist.

--- a/.agents/rules/007-no-breakage.md
+++ b/.agents/rules/007-no-breakage.md
@@ -1,0 +1,18 @@
+---
+trigger: always_on
+alwaysApply: true
+description: Policy for public API stability and backward compatibility
+globs: *
+---
+
+# No-Breakage Policy
+
+Termdash is a published Go library used by downstream projects. Before suggesting or making changes that affect the public API:
+
+- **Analyze the codebase** (e.g. search for usages of the type, function, or interface) to assess impact on both internal code and downstream consumers.
+- **Public API types:** If changing exported types, function signatures, or interface contracts in non-`/private/` packages, ensure backward compatibility. Prefer additive changes (new optional fields via functional options, new methods) over breaking modifications.
+- **Widget API:** If modifying `widgetapi.Widget` or related interfaces, check all widget implementations for compatibility. Every widget must continue to compile and pass tests.
+- **Private packages:** Changes to packages under `/private/` have more flexibility since they are explicitly not part of the public API. However, still check all internal consumers.
+- **Breaking changes:** If a breaking change is truly necessary, call it out explicitly to the user and document it for the `CHANGELOG.md`. The project has not yet reached v1.0.0, so breaking changes are permitted but should be minimized.
+
+When in doubt, prefer smaller, backward-compatible changes and call out any breaking changes explicitly.

--- a/.agents/rules/009-tests-coverage.md
+++ b/.agents/rules/009-tests-coverage.md
@@ -1,0 +1,16 @@
+---
+trigger: always_on
+alwaysApply: true
+description: Unit test requirements and coverage standards for Go code
+globs: *
+---
+
+# Tests and Coverage
+
+- **Unit tests for all logic:** Every new or meaningfully changed behavior (new widget feature, new drawing primitive, bug fix in core packages) must have **corresponding unit tests** in the same change. Place tests in the same package (e.g., `widget_test.go`, `draw_test.go`).
+- **Table-driven tests:** Use table-driven tests where multiple cases fit one pattern. See rule `013-go-table-driven-tests` for detailed guidelines.
+- **Test helpers:** Leverage existing test helpers in `private/faketerm/`, `private/canvas/testcanvas/`, and similar packages. When adding new drawing primitives, provide corresponding `Must*` test helpers.
+- **Race detector:** All tests must pass with the race detector enabled (`go test -race ./...`). Never introduce data races.
+- **Run tests before completing:** Before confirming a feature is complete, the agent MUST run `go test ./...` to verify all tests pass. Do not present code as finished without confirming it compiles and tests pass.
+- **Bug fixes:** For bug fixes, add a **regression test** that would have failed before the fix and passes after.
+- **Coverage direction:** When adding features, ensure test coverage does not regress. Aim for thorough coverage of state mutations, boundary conditions, and error paths.

--- a/.agents/rules/012-q-prompt.md
+++ b/.agents/rules/012-q-prompt.md
@@ -1,0 +1,14 @@
+---
+trigger: always_on
+description: Read only question mode
+globs: *
+---
+
+# Q: Prefix Rule
+
+If the user's prompt begins exactly with the prefix `q: ` (case-insensitive), you MUST operate in a **read-only / answer-only mode**. 
+
+Under this condition:
+1. You may use read-oriented tools (like reading files, searching code, or checking git status) to gather context to answer the user's question.
+2. You are **STRICTLY FORBIDDEN** from making any modifications to the codebase, creating new files, running destructive commands, or initiating any deployments.
+3. Your final output should only be an explanation, analysis, or direct answer to the question asked. 

--- a/.agents/rules/013-go-table-driven-tests.md
+++ b/.agents/rules/013-go-table-driven-tests.md
@@ -1,0 +1,16 @@
+---
+trigger: always_on
+description: Best practices for writing table-driven tests in Go
+globs: *
+---
+
+# Go Table-Driven Tests Best Practices
+
+When writing table-driven tests (TDTs) in Go within this repository, adhere strictly to the following guidelines:
+
+1. **Keep Setup Logic Uniform:** The power of table-driven testing comes from running multiple nuanced inputs through the exact same logic execution and setup phases.
+2. **Avoid Conditional Execution:** Do not introduce single-case conditional logic checks (e.g. `if tt.name == "SpecialCase" { ... }`) inside the standard test execution loop (`for _, tt := range tests { t.Run(...) }`).
+3. **Extract Complex Cases:** If a test case requires fundamentally different environment bootstrapping, mocking, or contextual injection that cannot be cleanly modeled as parameters within the table struct, **it does not belong in the table**. 
+4. **Standalone Functions:** Extract these highly custom scenarios into their own dedicated, standalone test functions (e.g., `func TestFeature_SpecialCase(t *testing.T)`).
+
+Following constraints like this ensures tests remain readable, modular, and easy to maintain without turning the iterative execution block into unreadable spaghetti code.

--- a/.agents/rules/014-compile-check.md
+++ b/.agents/rules/014-compile-check.md
@@ -1,0 +1,13 @@
+---
+trigger: always_on
+description: Verification of compilation before completing work
+globs: *
+---
+
+# Rule: Compile Check
+
+Whenever the agent delivers a modification to the source code, the agent **MUST explicitly run `go build ./...`** via the command line to verify that the code compiles flawlessly **before** confirming the feature is complete and asking for the user's review.
+
+Additionally, run `go vet ./...` to catch common issues that the compiler alone would not flag.
+
+Never blindly present or finalize code that has not been confirmed to compile and pass vet checks locally via terminal output.

--- a/.cursor/rules/001-persistent-rules.mdc
+++ b/.cursor/rules/001-persistent-rules.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/001-persistent-rules.md

--- a/.cursor/rules/002-documentation.mdc
+++ b/.cursor/rules/002-documentation.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/002-documentation.md

--- a/.cursor/rules/005-git-workflow.mdc
+++ b/.cursor/rules/005-git-workflow.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/005-git-workflow.md

--- a/.cursor/rules/006-go-best-practices.mdc
+++ b/.cursor/rules/006-go-best-practices.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/006-go-best-practices.md

--- a/.cursor/rules/007-no-breakage.mdc
+++ b/.cursor/rules/007-no-breakage.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/007-no-breakage.md

--- a/.cursor/rules/009-tests-coverage.mdc
+++ b/.cursor/rules/009-tests-coverage.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/009-tests-coverage.md

--- a/.cursor/rules/012-q-prompt.mdc
+++ b/.cursor/rules/012-q-prompt.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/012-q-prompt.md

--- a/.cursor/rules/013-go-table-driven-tests.mdc
+++ b/.cursor/rules/013-go-table-driven-tests.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/013-go-table-driven-tests.md

--- a/.cursor/rules/014-compile-check.mdc
+++ b/.cursor/rules/014-compile-check.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/014-compile-check.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AI Agent Configuration
+
+This repository strictly enforces AI rules located in the `.agents/rules/` directory.
+
+All project-specific rules are automatically loaded by the AI assistant and must be adhered to during any interaction or code generation task. New rules should follow the conventions established in `001-persistent-rules.md`.


### PR DESCRIPTION
## Summary

Establishes the `.agents/rules/` directory structure with Cursor `.mdc` symlinks.

## Rules Included (9 total)

| # | Rule | Origin | Adaptation |
|---|------|--------|------------|
| 001 | Persistent Rules | Both | Verbatim — rule format, symlink convention |
| 002 | Documentation | Both | References termdash docs (README, CONTRIBUTING, CHANGELOG, `doc/`) |
| 005 | Git Workflow | Both | Uses **`devel`** as base branch (nvie model), one-branch/one-PR policy |
| 006 | Go Best Practices | - | added termdash design philosophy (readability first, widget separation, test helpers) |
| 007 | No-Breakage | - | Focused on public API stability, `widgetapi` interface compat, `private/` boundary |
| 009 | Tests & Coverage | - | Go unit tests only (no E2E/frontend), race detector, termdash test helpers |
| 012 | Q-Prompt | Both | Verbatim — read-only question mode |
| 013 | Table-Driven Tests | - | Verbatim — TDT best practices |
| 014 | Compile Check | - | `go build ./...` + `go vet ./...` instead of `xcodebuild` |

## Structure

```
.agents/rules/*.md     ← authoritative rule files
.cursor/rules/*.mdc    ← symlinks for Cursor auto-loading
AGENTS.md              ← top-level pointer to rules directory
```