### PR TITLE
Update GitHub Actions workflow to run on all PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "master", "devel" ]
   pull_request:
-
+    branches: [ "master", "devel" ]
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ "master", "devel" ]
   pull_request:
-    branches: [ "master", "devel" ]
 
 jobs:
 
@@ -29,8 +28,6 @@ jobs:
       run: |
         go install golang.org/x/tools/cmd/cover@latest
         go install github.com/mattn/goveralls@latest
-        go install golang.org/x/lint/golint@latest
-        go get -t ./...
 
     - name: Test
       run: go test -v -covermode=count -coverprofile=coverage.out ./...
@@ -42,4 +39,4 @@ jobs:
       run: diff -u <(echo -n) <(gofmt -d -s .)
 
     - name: Lint
-      run: diff -u <(echo -n) <(golint ./...)
+      run: go vet ./...


### PR DESCRIPTION
This PR updates the existing `.github/workflows/go.yml` workflow:
- Triggers tests on all pull requests unconditionally.
- Removes the deprecated `golint` tooling in favor of standard `go vet`.
- Removes `go get -t ./...` as Go modules fetch dependencies automatically during testing.
